### PR TITLE
Enforce required SECRET_KEY

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -5,7 +5,7 @@ from app.schemas.user import UserCreate
 from app.crud import user
 from jose import jwt
 import os
-SECRET_KEY = os.getenv("SECRET_KEY", "secret")
+SECRET_KEY = os.environ["SECRET_KEY"]
 ALGORITHM = os.getenv("ALGORITHM", "HS256")
 router = APIRouter(tags=["Auth"])
 


### PR DESCRIPTION
## Summary
- make SECRET_KEY mandatory in auth routes

## Testing
- `python - <<'EOF'
import app.routes.auth
EOF` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685e7c8d02148323b42a0e84c36b2d37