### PR TITLE
Prevent duplicate emails on user creation

### DIFF
--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -1,9 +1,17 @@
 from sqlalchemy.orm import Session
+from fastapi import HTTPException
 from app.models.user import User
 from passlib.context import CryptContext
 import uuid
+
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
 def create_user(db: Session, email: str, password: str):
+    existing_user = db.query(User).filter(User.email == email).first()
+    if existing_user:
+        raise HTTPException(status_code=409, detail="Email already registered")
+
     hashed_password = pwd_context.hash(password)
     db_user = User(id=str(uuid.uuid4()), email=email, hashed_password=hashed_password)
     db.add(db_user)

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.database import SessionLocal
 from app.schemas.user import UserCreate, UserResponse
@@ -13,5 +13,9 @@ def get_db():
         db.close()
 @router.post("/", response_model=UserResponse)
 def create_user_route(user_data: UserCreate, db: Session = Depends(get_db)):
+    existing_user = user.get_user_by_email(db, user_data.email)
+    if existing_user:
+        raise HTTPException(status_code=409, detail="Email already registered")
+
     db_user = user.create_user(db, user_data.email, user_data.password)
     return db_user


### PR DESCRIPTION
## Summary
- validate uniqueness of user emails in `create_user`
- check for duplicate emails in the `/users/` route

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_685e7c8e7d8483239f32a52c578312ee