### PR TITLE
Add EmailStr and SecretStr support

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -18,7 +18,9 @@ def get_db():
 @router.post("/login")
 def login(form_data: UserCreate, db: Session = Depends(get_db)):
     db_user = user.get_user_by_email(db, form_data.email)
-    if not db_user or not user.verify_password(form_data.password, db_user.hashed_password):
+    if not db_user or not user.verify_password(
+        form_data.password.get_secret_value(), db_user.hashed_password
+    ):
         raise HTTPException(status_code=400, detail="Invalid credentials")
     token = jwt.encode({"sub": db_user.email}, SECRET_KEY, algorithm=ALGORITHM)
     return {"access_token": token, "token_type": "bearer"}

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -13,5 +13,7 @@ def get_db():
         db.close()
 @router.post("/", response_model=UserResponse)
 def create_user_route(user_data: UserCreate, db: Session = Depends(get_db)):
-    db_user = user.create_user(db, user_data.email, user_data.password)
+    db_user = user.create_user(
+        db, user_data.email, user_data.password.get_secret_value()
+    )
     return db_user

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr, SecretStr
 class UserCreate(BaseModel):
-    email: str
-    password: str
+    email: EmailStr
+    password: SecretStr
 class UserResponse(BaseModel):
     id: str
     email: str


### PR DESCRIPTION
## Summary
- use `EmailStr` and `SecretStr` in `UserCreate`
- update routes to handle `SecretStr`

## Testing
- `python -m py_compile $(git ls-files "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_685e7c90cb1c832396768a90803aa832