### PR TITLE
Use getenv for secret key

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -5,7 +5,11 @@ from app.schemas.user import UserCreate
 from app.crud import user
 from jose import jwt
 import os
-SECRET_KEY = os.environ["SECRET_KEY"]
+
+SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("SECRET_KEY environment variable not set")
+
 ALGORITHM = os.getenv("ALGORITHM", "HS256")
 router = APIRouter(tags=["Auth"])
 


### PR DESCRIPTION
## Summary
- use `os.getenv` for SECRET_KEY retrieval
- raise runtime error if SECRET_KEY is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7e363d28832382754663c19f00bc