### PR TITLE
Fix bcrypt version to avoid warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sqlalchemy
 asyncpg
 python-dotenv
 passlib[bcrypt]
+bcrypt<4.0
 python-jose[cryptography]
 email-validator
 apscheduler


### PR DESCRIPTION
## Summary
- specify `bcrypt<4.0` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7f2513b48323b861aa556f80412c