### PR TITLE
Move table creation to startup event

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,9 +3,13 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.database import Base, engine
 from app.routes import users, auth, events, todo, determinazioni
 
-Base.metadata.create_all(bind=engine)
-
 app = FastAPI()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Create database tables on application startup."""
+    Base.metadata.create_all(bind=engine)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- trigger database table creation using FastAPI startup event

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e963093088323b976ce16a94826c9