### PR TITLE
Add check for DATABASE_URL

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -4,6 +4,8 @@ from sqlalchemy.orm import sessionmaker
 import os
 
 DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL environment variable not set")
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()


### PR DESCRIPTION
## Summary
- fail fast when `DATABASE_URL` is missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ece703f948323bba8f40cec371922