### PR TITLE
Add pytest setup and basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ The API will be available at `http://localhost:8000/` by default.
 
 ## Running tests
 
-This repository does not currently include automated tests. If you add tests,
-install `pytest` in your virtual environment and run:
+Automated tests are written with `pytest`. After installing the requirements
+and setting the `DATABASE_URL` environment variable (for example to
+`sqlite:///./test.db`), run:
 
 ```bash
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-jose[cryptography]
 email-validator
 apscheduler
 psycopg2-binary
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.database import Base
+
+@pytest.fixture(scope="session")
+def engine():
+    engine = create_engine(os.environ["DATABASE_URL"], connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    yield engine
+    engine.dispose()
+
+@pytest.fixture
+def db_session(engine):
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+from app.crud import event as event_crud
+from app.schemas.event import EventCreate
+
+
+def test_create_event(db_session):
+    data = EventCreate(titolo="Test", descrizione="desc", data_ora=datetime.utcnow(), is_public=True)
+    new_event = event_crud.create_event(db_session, data)
+    assert new_event.titolo == "Test"
+    assert new_event.id is not None

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,7 @@
+from app.crud import user as user_crud
+
+
+def test_create_user(db_session):
+    new_user = user_crud.create_user(db_session, "user@example.com", "secret")
+    assert new_user.email == "user@example.com"
+    assert user_crud.verify_password("secret", new_user.hashed_password)


### PR DESCRIPTION
## Summary
- add initial pytest configuration with SQLite test database
- create simple user and event tests
- document running `pytest`
- include pytest in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685ee705113883239235f51ac79af1f4