### PR TITLE
Improve docs for scheduler and email utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 DATABASE_URL=postgresql://user:password@host:port/dbname
 SECRET_KEY=change_me
 ALGORITHM=HS256  # optional
+SMTP_HOST=smtp.example.com  # optional, only needed if sending emails
+SMTP_PORT=587               # optional
+SMTP_USER=example_user      # optional
+SMTP_PASSWORD=example_pass  # optional

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ This repository contains a FastAPI backend used by Segretaria Digitale.
 - `SECRET_KEY` – secret key used to sign JWT tokens.
 - `ALGORITHM` – (optional) algorithm used for JWT; defaults to `HS256`.
 
+### Email configuration (optional)
+
+The `app.utils.email` module can send basic emails using SMTP. Configure the
+following variables if you wish to use this functionality:
+
+- `SMTP_HOST` – address of the SMTP server.
+- `SMTP_PORT` – (optional) port number, defaults to `587`.
+- `SMTP_USER` – username for authentication (if required).
+- `SMTP_PASSWORD` – password for authentication (if required).
+
 ## Running the server
 
 After installing dependencies and setting the environment variables, start the
@@ -29,6 +39,10 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000
 ```
 
 The API will be available at `http://localhost:8000/` by default.
+
+The application starts a small background scheduler defined in
+`app/scheduler.py`. By default it runs a job every minute that prints a message
+to the console. You can modify or add jobs in that module to suit your needs.
 
 ## Running tests
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1,10 +1,15 @@
-"""Simple APScheduler setup with a sample job."""
+"""Simple APScheduler setup with a sample job.
+
+The scheduler is started on application startup from ``app.main`` and
+shut down on application shutdown.  To add your own background tasks simply
+define a function and register it with ``scheduler.add_job``.
+"""
 
 from apscheduler.schedulers.background import BackgroundScheduler
 
 
 def sample_job() -> None:
-    """Job that runs periodically and prints a message."""
+    """Job that runs periodically and prints a message to the console."""
     print("Sample scheduler job executed")
 
 

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers for the application."""
+
+# Re-export the :func:`send_email` helper so modules can simply do:
+# ``from app.utils import send_email``.
+
+from .email import send_email

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -1,4 +1,9 @@
-"""Utility functions for sending email via SMTP."""
+"""Utility functions for sending email via SMTP.
+
+`send_email` provides a very small wrapper around :class:`smtplib.SMTP` that
+loads connection details from environment variables.  It is intentionally simple
+so that it can be reused in background jobs or request handlers.
+"""
 
 import os
 import smtplib


### PR DESCRIPTION
## Summary
- document SMTP email configuration
- describe the background scheduler
- clarify scheduler and email helper modules
- re-export `send_email` in `app.utils`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee7039d58832389a73349617fe08e