### PR TITLE
Comment out migrations step

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -35,10 +35,10 @@ jobs:
     - name: Install dependencies
       run: pip install -r requirements.txt
 
-    - name: Run migrations
-      run: alembic upgrade head
-      env:
-        DATABASE_URL: ${{ env.DATABASE_URL }}
+    # - name: Run migrations
+    #   run: alembic upgrade head
+    #   env:
+    #     DATABASE_URL: ${{ env.DATABASE_URL }}
 
     - name: Deploy to Render
       run: |


### PR DESCRIPTION
## Summary
- remove Alembic migration execution from deploy-backend workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685eed2f5774832389e0067a55a0450a