### PR TITLE
Add configurable expiry to JWT login

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains a FastAPI backend used by Segretaria Digitale.
 - `DATABASE_URL` – connection string for the PostgreSQL database.
 - `SECRET_KEY` – secret key used to sign JWT tokens.
 - `ALGORITHM` – (optional) algorithm used for JWT; defaults to `HS256`.
+- `ACCESS_TOKEN_EXPIRE_MINUTES` – (optional) lifetime of access tokens in minutes; defaults to `30`.
 
 ### Email configuration (optional)
 

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -5,12 +5,14 @@ from app.schemas.user import UserCreate
 from app.crud import user
 from jose import jwt
 import os
+import datetime
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 if not SECRET_KEY:
     raise RuntimeError("SECRET_KEY environment variable not set")
 
 ALGORITHM = os.getenv("ALGORITHM", "HS256")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30"))
 router = APIRouter(tags=["Auth"])
 
 @router.post("/login")
@@ -18,5 +20,7 @@ def login(form_data: UserCreate, db: Session = Depends(get_db)):
     db_user = user.get_user_by_email(db, form_data.email)
     if not db_user or not user.verify_password(form_data.password, db_user.hashed_password):
         raise HTTPException(status_code=400, detail="Invalid credentials")
-    token = jwt.encode({"sub": db_user.email}, SECRET_KEY, algorithm=ALGORITHM)
+    expire = datetime.datetime.utcnow() + datetime.timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    payload = {"sub": db_user.email, "exp": int(expire.timestamp())}
+    token = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
     return {"access_token": token, "token_type": "bearer"}


### PR DESCRIPTION
## Summary
- include expiration claim in JWT tokens
- make token lifetime configurable via `ACCESS_TOKEN_EXPIRE_MINUTES`
- document new variable in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685eed33eb4c8323ba956c69c88f4766