### PR TITLE
Remove asyncpg dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This repository contains a FastAPI backend used by Segretaria Digitale.
    ```
 3. Copy `.env.example` to `.env` and adjust the values as needed.
 
+If asynchronous database access becomes necessary later on, add `asyncpg` to
+`requirements.txt` and configure SQLAlchemy with its async engine.
+
 ## Required environment variables
 
 - `DATABASE_URL` – connection string for the PostgreSQL database.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 fastapi
 uvicorn[standard]
 sqlalchemy
-asyncpg
 python-dotenv
 passlib[bcrypt]
 bcrypt<4.0


### PR DESCRIPTION
## Summary
- remove deprecated asyncpg requirement
- note how to add async support in README

## Testing
- `pytest -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685eed379d708323837a88a7dc115568