### PR TITLE
Add CRUD tests for events, todos and determinazioni

### DIFF
--- a/tests/test_determinazioni.py
+++ b/tests/test_determinazioni.py
@@ -1,0 +1,54 @@
+import os
+from fastapi.testclient import TestClient
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+from app.main import app
+from tests.test_users import setup_db
+
+client = TestClient(app)
+
+def test_create_determinazione(setup_db):
+    data = {
+        "capitolo": "A",
+        "numero": "1",
+        "somma": 100.0,
+        "scadenza": "2023-01-01T00:00:00",
+    }
+    response = client.post("/determinazioni/", json=data)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["capitolo"] == "A"
+    assert "id" in body
+
+
+def test_update_determinazione(setup_db):
+    res = client.post(
+        "/determinazioni/",
+        json={"capitolo": "A", "numero": "1", "somma": 100.0, "scadenza": "2023-01-01T00:00:00"},
+    )
+    det_id = res.json()["id"]
+    response = client.put(
+        f"/determinazioni/{det_id}",
+        json={"capitolo": "B", "numero": "1", "somma": 200.0, "scadenza": "2023-02-01T00:00:00"},
+    )
+    assert response.status_code == 200
+    assert response.json()["capitolo"] == "B"
+
+
+def test_list_determinazioni(setup_db):
+    client.post("/determinazioni/", json={"capitolo": "A", "numero": "1", "somma": 50.0, "scadenza": "2023-01-01T00:00:00"})
+    client.post("/determinazioni/", json={"capitolo": "B", "numero": "2", "somma": 75.0, "scadenza": "2023-01-02T00:00:00"})
+    response = client.get("/determinazioni/")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test_delete_determinazione(setup_db):
+    res = client.post("/determinazioni/", json={"capitolo": "A", "numero": "1", "somma": 50.0, "scadenza": "2023-01-01T00:00:00"})
+    det_id = res.json()["id"]
+    response = client.delete(f"/determinazioni/{det_id}")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert client.get("/determinazioni/").json() == []

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,73 @@
+import os
+from fastapi.testclient import TestClient
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+from app.main import app
+from tests.test_users import setup_db
+
+client = TestClient(app)
+
+def test_create_event(setup_db):
+    data = {
+        "titolo": "Meeting",
+        "descrizione": "Desc",
+        "data_ora": "2023-01-01T09:00:00",
+        "is_public": True,
+    }
+    response = client.post("/events/", json=data)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["titolo"] == "Meeting"
+    assert "id" in body
+
+
+def test_update_event(setup_db):
+    res = client.post(
+        "/events/",
+        json={
+            "titolo": "Old",
+            "descrizione": "",
+            "data_ora": "2023-01-01T09:00:00",
+            "is_public": False,
+        },
+    )
+    event_id = res.json()["id"]
+    response = client.put(
+        f"/events/{event_id}",
+        json={
+            "titolo": "New",
+            "descrizione": "",
+            "data_ora": "2023-01-02T10:00:00",
+            "is_public": True,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["titolo"] == "New"
+
+
+def test_list_events(setup_db):
+    client.post(
+        "/events/",
+        json={"titolo": "A", "descrizione": "", "data_ora": "2023-01-01T09:00:00", "is_public": False},
+    )
+    client.post(
+        "/events/",
+        json={"titolo": "B", "descrizione": "", "data_ora": "2023-01-02T09:00:00", "is_public": False},
+    )
+    response = client.get("/events/")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test_delete_event(setup_db):
+    res = client.post(
+        "/events/",
+        json={"titolo": "A", "descrizione": "", "data_ora": "2023-01-01T09:00:00", "is_public": False},
+    )
+    event_id = res.json()["id"]
+    response = client.delete(f"/events/{event_id}")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert client.get("/events/").json() == []

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,0 +1,58 @@
+import os
+from datetime import datetime
+from fastapi.testclient import TestClient
+import pytest
+
+# Use same test database
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+from app.main import app
+
+from tests.test_users import setup_db  # reuse fixture
+
+client = TestClient(app)
+
+def test_create_todo(setup_db):
+    response = client.post(
+        "/todo/",
+        json={"descrizione": "Task", "scadenza": "2023-01-01T10:00:00"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["descrizione"] == "Task"
+    assert "id" in data
+
+
+def test_update_todo(setup_db):
+    create = client.post(
+        "/todo/",
+        json={"descrizione": "Old", "scadenza": "2023-01-01T10:00:00"},
+    )
+    todo_id = create.json()["id"]
+    response = client.put(
+        f"/todo/{todo_id}",
+        json={"descrizione": "New", "scadenza": "2023-02-01T10:00:00"},
+    )
+    assert response.status_code == 200
+    assert response.json()["descrizione"] == "New"
+
+
+def test_list_todos(setup_db):
+    client.post("/todo/", json={"descrizione": "A", "scadenza": "2023-01-01T10:00:00"})
+    client.post("/todo/", json={"descrizione": "B", "scadenza": "2023-01-02T10:00:00"})
+    response = client.get("/todo/")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+
+
+def test_delete_todo(setup_db):
+    res = client.post(
+        "/todo/",
+        json={"descrizione": "A", "scadenza": "2023-01-01T10:00:00"},
+    )
+    todo_id = res.json()["id"]
+    response = client.delete(f"/todo/{todo_id}")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert client.get("/todo/").json() == []


### PR DESCRIPTION
## Summary
- add tests for create, update, list and delete on `/todo` resource
- add tests for create, update, list and delete on `/events` resource
- add tests for create, update, list and delete on `/determinazioni` resource

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685eed3c12ac83238a90f54926ba3331