### PR TITLE
Remove unused pytest imports in tests

### DIFF
--- a/tests/test_determinazioni.py
+++ b/tests/test_determinazioni.py
@@ -1,6 +1,5 @@
 import os
 from fastapi.testclient import TestClient
-import pytest
 
 os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,5 @@
 import os
 from fastapi.testclient import TestClient
-import pytest
 
 os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,7 +1,5 @@
 import os
-from datetime import datetime
 from fastapi.testclient import TestClient
-import pytest
 
 # Use same test database
 os.environ["DATABASE_URL"] = "sqlite:///./test.db"


### PR DESCRIPTION
## Summary
- clean up test imports by removing `pytest` usages
- drop unused `datetime` import from todo tests
- verify syntax with `compileall`

## Testing
- `python -m compileall -q tests`

------
https://chatgpt.com/codex/tasks/task_e_685f1015c8108323a2e4c5a2f1e745ce