### PR TITLE
Add descrizione to determinazioni

### DIFF
--- a/app/models/determinazione.py
+++ b/app/models/determinazione.py
@@ -6,5 +6,6 @@ class Determinazione(Base):
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
     capitolo = Column(String, nullable=False)
     numero = Column(String, nullable=False)
+    descrizione = Column(String, nullable=True)
     somma = Column(Float, nullable=False)
     scadenza = Column(DateTime, nullable=False)

--- a/app/schemas/determinazione.py
+++ b/app/schemas/determinazione.py
@@ -3,6 +3,7 @@ from datetime import datetime
 class DeterminazioneCreate(BaseModel):
     capitolo: str
     numero: str
+    descrizione: str | None = None
     somma: float
     scadenza: datetime
 class DeterminazioneResponse(DeterminazioneCreate):

--- a/tests/test_determinazioni.py
+++ b/tests/test_determinazioni.py
@@ -12,6 +12,7 @@ def test_create_determinazione(setup_db):
     data = {
         "capitolo": "A",
         "numero": "1",
+        "descrizione": "Det",
         "somma": 100.0,
         "scadenza": "2023-01-01T00:00:00",
     }
@@ -19,33 +20,35 @@ def test_create_determinazione(setup_db):
     assert response.status_code == 200
     body = response.json()
     assert body["capitolo"] == "A"
+    assert body["descrizione"] == "Det"
     assert "id" in body
 
 
 def test_update_determinazione(setup_db):
     res = client.post(
         "/determinazioni/",
-        json={"capitolo": "A", "numero": "1", "somma": 100.0, "scadenza": "2023-01-01T00:00:00"},
+        json={"capitolo": "A", "numero": "1", "descrizione": "", "somma": 100.0, "scadenza": "2023-01-01T00:00:00"},
     )
     det_id = res.json()["id"]
     response = client.put(
         f"/determinazioni/{det_id}",
-        json={"capitolo": "B", "numero": "1", "somma": 200.0, "scadenza": "2023-02-01T00:00:00"},
+        json={"capitolo": "B", "numero": "1", "descrizione": "", "somma": 200.0, "scadenza": "2023-02-01T00:00:00"},
     )
     assert response.status_code == 200
     assert response.json()["capitolo"] == "B"
+    assert "descrizione" in response.json()
 
 
 def test_list_determinazioni(setup_db):
-    client.post("/determinazioni/", json={"capitolo": "A", "numero": "1", "somma": 50.0, "scadenza": "2023-01-01T00:00:00"})
-    client.post("/determinazioni/", json={"capitolo": "B", "numero": "2", "somma": 75.0, "scadenza": "2023-01-02T00:00:00"})
+    client.post("/determinazioni/", json={"capitolo": "A", "numero": "1", "descrizione": "", "somma": 50.0, "scadenza": "2023-01-01T00:00:00"})
+    client.post("/determinazioni/", json={"capitolo": "B", "numero": "2", "descrizione": "", "somma": 75.0, "scadenza": "2023-01-02T00:00:00"})
     response = client.get("/determinazioni/")
     assert response.status_code == 200
     assert len(response.json()) == 2
 
 
 def test_delete_determinazione(setup_db):
-    res = client.post("/determinazioni/", json={"capitolo": "A", "numero": "1", "somma": 50.0, "scadenza": "2023-01-01T00:00:00"})
+    res = client.post("/determinazioni/", json={"capitolo": "A", "numero": "1", "descrizione": "", "somma": 50.0, "scadenza": "2023-01-01T00:00:00"})
     det_id = res.json()["id"]
     response = client.delete(f"/determinazioni/{det_id}")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add optional `descrizione` field to `Determinazione` model and schema
- include `descrizione` in CRUD tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685f1670b574832385134bbe6dfafb41