### PR TITLE
Add httpx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a FastAPI backend used by Segretaria Digitale.
 ## Setup
 
 1. Ensure you have **Python 3.10+** installed.
-2. Create a virtual environment and install dependencies:
+2. Create a virtual environment and install dependencies (including `httpx`):
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-jose[cryptography]
 apscheduler
 psycopg2-binary
 pytest
+httpx


### PR DESCRIPTION
## Summary
- include `httpx` in `requirements.txt`
- document `httpx` install step in the setup guide

## Testing
- `pytest -q` *(fails: No module named 'httpx')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f1a4d8f908323b135834f6c37f504