### PR TITLE
Set SECRET_KEY for tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+# Ensure a default secret key is available for tests
+os.environ.setdefault("SECRET_KEY", "test-secret-key")


### PR DESCRIPTION
## Summary
- ensure a default `SECRET_KEY` is provided during tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685f1a4f21048323ada47bc79b9a2c72