### PR TITLE
Move setup_db fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+import pytest
+
+# Ensure DATABASE_URL is set for tests
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from app.database import Base, engine
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    """Create a fresh database for each test."""
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)

--- a/tests/test_determinazioni.py
+++ b/tests/test_determinazioni.py
@@ -4,7 +4,6 @@ from fastapi.testclient import TestClient
 os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from app.main import app
-from tests.test_users import setup_db
 
 client = TestClient(app)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,7 +4,6 @@ from fastapi.testclient import TestClient
 os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from app.main import app
-from tests.test_users import setup_db
 
 client = TestClient(app)
 

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -6,8 +6,6 @@ os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from app.main import app
 
-from tests.test_users import setup_db  # reuse fixture
-
 client = TestClient(app)
 
 def test_create_todo(setup_db):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,19 +1,10 @@
 import os
-import pytest
 from fastapi.testclient import TestClient
 
 # Set test database before importing the app
 os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from app.main import app
-from app.database import Base, engine
-
-@pytest.fixture(autouse=True)
-def setup_db():
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-    yield
-    Base.metadata.drop_all(bind=engine)
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- centralize the `setup_db` fixture in `tests/conftest.py`
- remove fixture imports from individual test modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*
- `pip install -q -r requirements.txt` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685f1a51491883239067f433420b4f03