### PR TITLE
Add access token expiry variable example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 DATABASE_URL=postgresql://user:password@host/dbname
 SECRET_KEY=changeme
 ALGORITHM=HS256
+
+ACCESS_TOKEN_EXPIRE_MINUTES=30


### PR DESCRIPTION
## Summary
- add ACCESS_TOKEN_EXPIRE_MINUTES to `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685f1a525b388323a9b19ccefc9bd847