### PR TITLE
Replace print with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000
 The API will be available at `http://localhost:8000/` by default.
 
 The application starts a small background scheduler defined in
-`app/scheduler.py`. By default it runs a job every minute that prints a message
-to the console. You can modify or add jobs in that module to suit your needs.
+`app/scheduler.py`. By default it runs a job every minute that logs a message.
+You can edit `sample_job` or remove the `scheduler.add_job` line in that file
+to disable the task. Alternatively comment out the call to `scheduler.start()`
+in `app/main.py` to disable the scheduler entirely.
 
 ## Running tests
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -6,12 +6,16 @@ define a function and register it with ``scheduler.add_job``.
 """
 
 from apscheduler.schedulers.background import BackgroundScheduler
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def sample_job() -> None:
-    """Job that runs periodically and prints a message to the console."""
-    # print("Sample scheduler job executed")
-    pass
+    """Job that runs periodically and logs a message."""
+    logger.info("Sample scheduler job executed")
+
 
 
 scheduler = BackgroundScheduler()


### PR DESCRIPTION
## Summary
- log execution of sample scheduler job
- explain in README how to disable the scheduler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685f205fb90c8323ae176c4f043b2138