### PR TITLE
Add docstrings for API route and CRUD modules

### DIFF
--- a/app/crud/determinazione.py
+++ b/app/crud/determinazione.py
@@ -1,14 +1,23 @@
 from sqlalchemy.orm import Session
 from app.models.determinazione import Determinazione
+
+
 def create_determinazione(db: Session, data):
+    """Persist a new :class:`Determinazione` using the provided schema."""
     db_det = Determinazione(**data.dict())
     db.add(db_det)
     db.commit()
     db.refresh(db_det)
     return db_det
+
+
 def get_determinazioni(db: Session):
+    """Return a list of all ``Determinazione`` entries."""
     return db.query(Determinazione).all()
+
+
 def update_determinazione(db: Session, determinazione_id: str, data):
+    """Update an existing ``Determinazione`` or return ``None`` if absent."""
     db_det = db.query(Determinazione).filter(Determinazione.id == determinazione_id).first()
     if not db_det:
         return None
@@ -16,7 +25,10 @@ def update_determinazione(db: Session, determinazione_id: str, data):
         setattr(db_det, key, value)
     db.commit()
     return db_det
+
+
 def delete_determinazione(db: Session, determinazione_id: str):
+    """Delete a ``Determinazione`` by id if present and return it."""
     db_det = db.query(Determinazione).filter(Determinazione.id == determinazione_id).first()
     if db_det:
         db.delete(db_det)

--- a/app/crud/event.py
+++ b/app/crud/event.py
@@ -1,14 +1,23 @@
 from sqlalchemy.orm import Session
 from app.models.event import Event
+
+
 def create_event(db: Session, data):
+    """Insert a new :class:`Event` from the given schema."""
     db_event = Event(**data.dict())
     db.add(db_event)
     db.commit()
     db.refresh(db_event)
     return db_event
+
+
 def get_events(db: Session):
+    """Retrieve all events from storage."""
     return db.query(Event).all()
+
+
 def update_event(db: Session, event_id: str, data):
+    """Update an ``Event`` by id or return ``None`` if missing."""
     db_event = db.query(Event).filter(Event.id == event_id).first()
     if not db_event:
         return None
@@ -16,7 +25,10 @@ def update_event(db: Session, event_id: str, data):
         setattr(db_event, key, value)
     db.commit()
     return db_event
+
+
 def delete_event(db: Session, event_id: str):
+    """Delete the event with ``event_id`` if it exists."""
     db_event = db.query(Event).filter(Event.id == event_id).first()
     if db_event:
         db.delete(db_event)

--- a/app/crud/todo.py
+++ b/app/crud/todo.py
@@ -1,14 +1,23 @@
 from sqlalchemy.orm import Session
 from app.models.todo import ToDo
+
+
 def create_todo(db: Session, data):
+    """Create a ``ToDo`` entry from the supplied schema."""
     db_todo = ToDo(**data.dict())
     db.add(db_todo)
     db.commit()
     db.refresh(db_todo)
     return db_todo
+
+
 def get_todos(db: Session):
+    """Return all stored ``ToDo`` objects."""
     return db.query(ToDo).all()
+
+
 def update_todo(db: Session, todo_id: str, data):
+    """Update a ``ToDo`` or return ``None`` if it does not exist."""
     db_todo = db.query(ToDo).filter(ToDo.id == todo_id).first()
     if not db_todo:
         return None
@@ -16,7 +25,10 @@ def update_todo(db: Session, todo_id: str, data):
         setattr(db_todo, key, value)
     db.commit()
     return db_todo
+
+
 def delete_todo(db: Session, todo_id: str):
+    """Remove a todo entry and return it if found."""
     db_todo = db.query(ToDo).filter(ToDo.id == todo_id).first()
     if db_todo:
         db.delete(db_todo)

--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -8,6 +8,7 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 def create_user(db: Session, email: str, password: str):
+    """Create and return a new user with a hashed password."""
     existing_user = db.query(User).filter(User.email == email).first()
     if existing_user:
         raise HTTPException(status_code=409, detail="Email already registered")
@@ -18,7 +19,13 @@ def create_user(db: Session, email: str, password: str):
     db.commit()
     db.refresh(db_user)
     return db_user
+
+
 def get_user_by_email(db: Session, email: str):
+    """Return a user instance matching ``email`` or ``None``."""
     return db.query(User).filter(User.email == email).first()
+
+
 def verify_password(plain_password, hashed_password):
+    """Return ``True`` if the plaintext password matches the hashed one."""
     return pwd_context.verify(plain_password, hashed_password)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -17,6 +17,12 @@ router = APIRouter(tags=["Auth"])
 
 @router.post("/login")
 def login(form_data: UserCreate, db: Session = Depends(get_db)):
+    """Authenticate a user and issue a JWT access token.
+
+    The provided credentials are validated against the stored user data.
+    On success the generated token and token type are returned, otherwise a
+    400 HTTP error is raised.
+    """
     db_user = user.get_user_by_email(db, form_data.email)
     if not db_user or not user.verify_password(form_data.password, db_user.hashed_password):
         raise HTTPException(status_code=400, detail="Invalid credentials")

--- a/app/routes/determinazioni.py
+++ b/app/routes/determinazioni.py
@@ -8,14 +8,20 @@ router = APIRouter(prefix="/determinazioni", tags=["Determinazioni"])
 
 @router.post("/", response_model=DeterminazioneResponse)
 def create_determinazione_route(data: DeterminazioneCreate, db: Session = Depends(get_db)):
+    """Create a new determinazione record and return it."""
     return determinazione.create_determinazione(db, data)
 
 @router.get("/", response_model=list[DeterminazioneResponse])
 def list_determinazioni(db: Session = Depends(get_db)):
+    """Return all determinazioni stored in the database."""
     return determinazione.get_determinazioni(db)
 
 @router.put("/{determinazione_id}", response_model=DeterminazioneResponse)
 def update_determinazione_route(determinazione_id: str, data: DeterminazioneCreate, db: Session = Depends(get_db)):
+    """Update an existing determinazione.
+
+    Raises a 404 error if the record does not exist.
+    """
     db_det = determinazione.update_determinazione(db, determinazione_id, data)
     if not db_det:
         raise HTTPException(status_code=404, detail="Determinazione not found")
@@ -23,6 +29,10 @@ def update_determinazione_route(determinazione_id: str, data: DeterminazioneCrea
 
 @router.delete("/{determinazione_id}")
 def delete_determinazione_route(determinazione_id: str, db: Session = Depends(get_db)):
+    """Delete a determinazione if it exists.
+
+    Returns ``{"ok": True}`` on success or raises 404 if not found.
+    """
     db_det = determinazione.delete_determinazione(db, determinazione_id)
     if not db_det:
         raise HTTPException(status_code=404, detail="Determinazione not found")

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -7,18 +7,22 @@ router = APIRouter(prefix="/events", tags=["Events"])
 
 @router.post("/", response_model=EventResponse)
 def create_event_route(data: EventCreate, db: Session = Depends(get_db)):
+    """Create a new event and return the stored model."""
     return event.create_event(db, data)
 @router.get("/", response_model=list[EventResponse])
 def list_events(db: Session = Depends(get_db)):
+    """Retrieve all events from the database."""
     return event.get_events(db)
 @router.put("/{event_id}", response_model=EventResponse)
 def update_event_route(event_id: str, data: EventCreate, db: Session = Depends(get_db)):
+    """Update an event by ``event_id`` or raise 404 if missing."""
     db_event = event.update_event(db, event_id, data)
     if not db_event:
         raise HTTPException(status_code=404, detail="Event not found")
     return db_event
 @router.delete("/{event_id}")
 def delete_event_route(event_id: str, db: Session = Depends(get_db)):
+    """Delete an event if present and confirm deletion."""
     db_event = event.delete_event(db, event_id)
     if not db_event:
         raise HTTPException(status_code=404, detail="Event not found")

--- a/app/routes/todo.py
+++ b/app/routes/todo.py
@@ -8,14 +8,17 @@ router = APIRouter(prefix="/todo", tags=["ToDo"])
 
 @router.post("/", response_model=ToDoResponse)
 def create_todo_route(data: ToDoCreate, db: Session = Depends(get_db)):
+    """Create a todo item and return it."""
     return todo.create_todo(db, data)
 
 @router.get("/", response_model=list[ToDoResponse])
 def list_todos(db: Session = Depends(get_db)):
+    """List all todo items."""
     return todo.get_todos(db)
 
 @router.put("/{todo_id}", response_model=ToDoResponse)
 def update_todo_route(todo_id: str, data: ToDoCreate, db: Session = Depends(get_db)):
+    """Update a todo and return the updated model or 404."""
     db_todo = todo.update_todo(db, todo_id, data)
     if not db_todo:
         raise HTTPException(status_code=404, detail="ToDo not found")
@@ -23,6 +26,7 @@ def update_todo_route(todo_id: str, data: ToDoCreate, db: Session = Depends(get_
 
 @router.delete("/{todo_id}")
 def delete_todo_route(todo_id: str, db: Session = Depends(get_db)):
+    """Remove a todo item if present and confirm deletion."""
     db_todo = todo.delete_todo(db, todo_id)
     if not db_todo:
         raise HTTPException(status_code=404, detail="ToDo not found")

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -7,6 +7,7 @@ router = APIRouter(prefix="/users", tags=["Users"])
 
 @router.post("/", response_model=UserResponse)
 def create_user_route(user_data: UserCreate, db: Session = Depends(get_db)):
+    """Register a new user if the email is not already taken."""
     existing_user = user.get_user_by_email(db, user_data.email)
     if existing_user:
         raise HTTPException(status_code=409, detail="Email already registered")


### PR DESCRIPTION
## Summary
- document auth login handler
- document CRUD routes for determinazioni, events, todo and users
- document CRUD helpers for determinazione, event, todo, user

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685f205e1300832392b15f3320b176ae