### PR TITLE
Add auth tests

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,34 @@
+import os
+from fastapi.testclient import TestClient
+
+# Use test database for these tests
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_login_success(setup_db):
+    client.post(
+        "/users/",
+        json={"email": "auth@example.com", "password": "secret"},
+    )
+    response = client.post(
+        "/login", json={"email": "auth@example.com", "password": "secret"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+
+
+def test_login_invalid_credentials(setup_db):
+    client.post(
+        "/users/",
+        json={"email": "wrong@example.com", "password": "secret"},
+    )
+    response = client.post(
+        "/login", json={"email": "wrong@example.com", "password": "bad"}
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- add test coverage for `/login` endpoint

## Testing
- `pytest -q tests/test_auth.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685f205bb2c48323b09fde207009f77e