### PR TITLE
Use runtime PDF upload root

### DIFF
--- a/app/crud/pdffile.py
+++ b/app/crud/pdffile.py
@@ -6,15 +6,18 @@ from fastapi import UploadFile
 from app.models.pdffile import PDFFile
 from app.schemas.pdffile import PDFFileCreate
 
-UPLOAD_ROOT = os.getenv("PDF_UPLOAD_ROOT", "uploads/pdfs")
 
-os.makedirs(UPLOAD_ROOT, exist_ok=True)
+def get_upload_root() -> str:
+    """Return the path where PDF files should be stored."""
+    root = os.getenv("PDF_UPLOAD_ROOT", "uploads/pdfs")
+    os.makedirs(root, exist_ok=True)
+    return root
 
 
 def create(db: Session, *, obj_in: PDFFileCreate, file: UploadFile) -> PDFFile:
     ext = os.path.splitext(file.filename)[1]
     fname = f"{uuid.uuid4()}{ext}"
-    path = os.path.join(UPLOAD_ROOT, fname)
+    path = os.path.join(get_upload_root(), fname)
     with open(path, "wb") as fp:
         shutil.copyfileobj(file.file, fp)
 

--- a/app/main.py
+++ b/app/main.py
@@ -28,9 +28,9 @@ app.include_router(todo.router)
 app.include_router(determinazioni.router)
 app.include_router(pdfs.router)
 
-from app.crud.pdffile import UPLOAD_ROOT
+from app.crud.pdffile import get_upload_root
 from fastapi.staticfiles import StaticFiles
-app.mount("/uploads", StaticFiles(directory=UPLOAD_ROOT), name="uploads")
+app.mount("/uploads", StaticFiles(directory=get_upload_root()), name="uploads")
 
 
 @app.on_event("shutdown")

--- a/app/routes/pdfs.py
+++ b/app/routes/pdfs.py
@@ -28,8 +28,8 @@ async def upload_pdf(
 
 @router.get("/{filename}")
 def get_pdf(filename: str):
-    from app.crud.pdffile import UPLOAD_ROOT
-    path = os.path.join(UPLOAD_ROOT, filename)
+    from app.crud.pdffile import get_upload_root
+    path = os.path.join(get_upload_root(), filename)
     if not os.path.exists(path):
         raise HTTPException(404)
     return FileResponse(path, media_type="application/pdf", filename=filename)


### PR DESCRIPTION
## Summary
- load `PDF_UPLOAD_ROOT` dynamically
- use helper in PDF routes and main

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686265f2d8688323b585a6530ef2bb9d