### PR TITLE
Fix pdf upload dir handling in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import shutil
+import importlib
 
 # Ensure DATABASE_URL is set for tests
 os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
@@ -20,5 +21,14 @@ def setup_db():
 def setup_upload_dir(tmp_path):
     upload_dir = tmp_path / "pdfs"
     os.environ["PDF_UPLOAD_ROOT"] = str(upload_dir)
+
+    # Reload pdffile module so it picks up the new environment variable
+    import app.crud.pdffile as pdffile
+    pdffile = importlib.reload(pdffile)
+
+    # Update the reference used by the PDF routes
+    import app.routes.pdfs as pdf_routes
+    pdf_routes.crud_pdffile = pdffile
+
     yield
     shutil.rmtree(str(upload_dir), ignore_errors=True)


### PR DESCRIPTION
## Summary
- ensure PDF files are written to per‑test upload dirs
- reload `pdffile` after changing the env var so app routes use the correct path

## Testing
- `pytest tests/test_pdfs.py::test_upload_pdf_and_list -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pytest tests/test_pdfs.py::test_upload_invalid_content_type -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686265f38ff8832398fc402a5f8d99b2