### PR TITLE
Close uploaded PDF files

### DIFF
--- a/app/crud/pdffile.py
+++ b/app/crud/pdffile.py
@@ -18,6 +18,9 @@ def create(db: Session, *, obj_in: PDFFileCreate, file: UploadFile) -> PDFFile:
     with open(path, "wb") as fp:
         shutil.copyfileobj(file.file, fp)
 
+    # Explicitly close the uploaded file to release resources
+    file.file.close()
+
     db_obj = PDFFile(title=obj_in.title, filename=fname)
     db.add(db_obj)
     db.commit()


### PR DESCRIPTION
## Summary
- release resources by closing the uploaded PDF file after copy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686265f4d18883239231c9b50c8e8de7