### PR TITLE
Secure ToDo endpoints per user

### DIFF
--- a/app/crud/todo.py
+++ b/app/crud/todo.py
@@ -1,24 +1,25 @@
 from sqlalchemy.orm import Session
 from app.models.todo import ToDo
+from app.models.user import User
 
 
-def create_todo(db: Session, data):
-    """Create a ``ToDo`` entry from the supplied schema."""
-    db_todo = ToDo(**data.dict())
+def create_todo(db: Session, data, user: User):
+    """Create a ``ToDo`` entry from the supplied schema for ``user``."""
+    db_todo = ToDo(**data.dict(), user_id=user.id)
     db.add(db_todo)
     db.commit()
     db.refresh(db_todo)
     return db_todo
 
 
-def get_todos(db: Session):
-    """Return all stored ``ToDo`` objects."""
-    return db.query(ToDo).all()
+def get_todos(db: Session, user: User):
+    """Return all ``ToDo`` objects owned by ``user``."""
+    return db.query(ToDo).filter(ToDo.user_id == user.id).all()
 
 
-def update_todo(db: Session, todo_id: str, data):
-    """Update a ``ToDo`` or return ``None`` if it does not exist."""
-    db_todo = db.query(ToDo).filter(ToDo.id == todo_id).first()
+def update_todo(db: Session, todo_id: str, data, user: User):
+    """Update a ``ToDo`` owned by ``user`` or return ``None`` if it does not exist."""
+    db_todo = db.query(ToDo).filter(ToDo.id == todo_id, ToDo.user_id == user.id).first()
     if not db_todo:
         return None
     for key, value in data.dict().items():
@@ -27,10 +28,11 @@ def update_todo(db: Session, todo_id: str, data):
     return db_todo
 
 
-def delete_todo(db: Session, todo_id: str):
-    """Remove a todo entry and return it if found."""
-    db_todo = db.query(ToDo).filter(ToDo.id == todo_id).first()
+def delete_todo(db: Session, todo_id: str, user: User):
+    """Remove a todo entry owned by ``user`` and return it if found."""
+    db_todo = db.query(ToDo).filter(ToDo.id == todo_id, ToDo.user_id == user.id).first()
     if db_todo:
         db.delete(db_todo)
         db.commit()
     return db_todo
+

--- a/app/models/todo.py
+++ b/app/models/todo.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Column, String, DateTime
+from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
 from app.database import Base
 import uuid
 class ToDo(Base):
@@ -6,3 +7,6 @@ class ToDo(Base):
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
     descrizione = Column(String, nullable=False)
     scadenza = Column(DateTime, nullable=False)
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    user = relationship("User", back_populates="todos")
+

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,7 +1,10 @@
 from sqlalchemy import Column, String
+from sqlalchemy.orm import relationship
 from app.database import Base
 class User(Base):
     __tablename__ = "users"
     id = Column(String, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
+    todos = relationship("ToDo", back_populates="user")
+

--- a/app/routes/todo.py
+++ b/app/routes/todo.py
@@ -1,33 +1,50 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from app.dependencies import get_db
+from app.dependencies import get_db, get_current_user
+from app.models.user import User
 from app.schemas.todo import ToDoCreate, ToDoResponse
 from app.crud import todo
 
 router = APIRouter(prefix="/todo", tags=["ToDo"],trailing_slash=False)
 
 @router.post("/", response_model=ToDoResponse)
-def create_todo_route(data: ToDoCreate, db: Session = Depends(get_db)):
-    """Create a todo item and return it."""
-    return todo.create_todo(db, data)
+def create_todo_route(
+    data: ToDoCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Create a todo item for the authenticated user."""
+    return todo.create_todo(db, data, current_user)
 
 @router.get("/", response_model=list[ToDoResponse])
-def list_todos(db: Session = Depends(get_db)):
-    """List all todo items."""
-    return todo.get_todos(db)
+def list_todos(
+    db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
+):
+    """List todo items for the authenticated user."""
+    return todo.get_todos(db, current_user)
 
 @router.put("/{todo_id}", response_model=ToDoResponse)
-def update_todo_route(todo_id: str, data: ToDoCreate, db: Session = Depends(get_db)):
-    """Update a todo and return the updated model or 404."""
-    db_todo = todo.update_todo(db, todo_id, data)
+def update_todo_route(
+    todo_id: str,
+    data: ToDoCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Update a todo owned by the authenticated user."""
+    db_todo = todo.update_todo(db, todo_id, data, current_user)
     if not db_todo:
         raise HTTPException(status_code=404, detail="ToDo not found")
     return db_todo
 
 @router.delete("/{todo_id}")
-def delete_todo_route(todo_id: str, db: Session = Depends(get_db)):
-    """Remove a todo item if present and confirm deletion."""
-    db_todo = todo.delete_todo(db, todo_id)
+def delete_todo_route(
+    todo_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Remove a todo item owned by the authenticated user."""
+    db_todo = todo.delete_todo(db, todo_id, current_user)
     if not db_todo:
         raise HTTPException(status_code=404, detail="ToDo not found")
     return {"ok": True}
+

--- a/app/schemas/todo.py
+++ b/app/schemas/todo.py
@@ -5,5 +5,7 @@ class ToDoCreate(BaseModel):
     scadenza: datetime
 class ToDoResponse(ToDoCreate):
     id: str
+    user_id: str
     class Config:
         orm_mode = True
+

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -8,47 +8,104 @@ from app.main import app
 
 client = TestClient(app)
 
+
+def auth_user(email: str):
+    resp = client.post("/users/", json={"email": email, "password": "secret"})
+    user_id = resp.json()["id"]
+    token = client.post(
+        "/login", json={"email": email, "password": "secret"}
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}, user_id
+
+
 def test_create_todo(setup_db):
+    headers, user_id = auth_user("todo@example.com")
     response = client.post(
         "/todo/",
         json={"descrizione": "Task", "scadenza": "2023-01-01T10:00:00"},
+        headers=headers,
     )
     assert response.status_code == 200
     data = response.json()
     assert data["descrizione"] == "Task"
+    assert data["user_id"] == user_id
     assert "id" in data
 
 
 def test_update_todo(setup_db):
+    headers, _ = auth_user("edit@example.com")
     create = client.post(
         "/todo/",
         json={"descrizione": "Old", "scadenza": "2023-01-01T10:00:00"},
+        headers=headers,
     )
     todo_id = create.json()["id"]
     response = client.put(
         f"/todo/{todo_id}",
         json={"descrizione": "New", "scadenza": "2023-02-01T10:00:00"},
+        headers=headers,
     )
     assert response.status_code == 200
     assert response.json()["descrizione"] == "New"
 
 
 def test_list_todos(setup_db):
-    client.post("/todo/", json={"descrizione": "A", "scadenza": "2023-01-01T10:00:00"})
-    client.post("/todo/", json={"descrizione": "B", "scadenza": "2023-01-02T10:00:00"})
-    response = client.get("/todo/")
+    headers, _ = auth_user("list@example.com")
+    client.post(
+        "/todo/",
+        json={"descrizione": "A", "scadenza": "2023-01-01T10:00:00"},
+        headers=headers,
+    )
+    client.post(
+        "/todo/",
+        json={"descrizione": "B", "scadenza": "2023-01-02T10:00:00"},
+        headers=headers,
+    )
+    response = client.get("/todo/", headers=headers)
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2
 
 
 def test_delete_todo(setup_db):
+    headers, _ = auth_user("del@example.com")
     res = client.post(
         "/todo/",
         json={"descrizione": "A", "scadenza": "2023-01-01T10:00:00"},
+        headers=headers,
     )
     todo_id = res.json()["id"]
-    response = client.delete(f"/todo/{todo_id}")
+    response = client.delete(f"/todo/{todo_id}", headers=headers)
     assert response.status_code == 200
     assert response.json()["ok"] is True
-    assert client.get("/todo/").json() == []
+    assert client.get("/todo/", headers=headers).json() == []
+
+
+def test_user_isolated_todos(setup_db):
+    h1, id1 = auth_user("u1@example.com")
+    h2, id2 = auth_user("u2@example.com")
+
+    client.post(
+        "/todo/",
+        json={"descrizione": "U1", "scadenza": "2023-01-01T10:00:00"},
+        headers=h1,
+    )
+    client.post(
+        "/todo/",
+        json={"descrizione": "U2", "scadenza": "2023-01-02T10:00:00"},
+        headers=h2,
+    )
+    client.post(
+        "/todo/",
+        json={"descrizione": "U1B", "scadenza": "2023-01-03T10:00:00"},
+        headers=h1,
+    )
+
+    res1 = client.get("/todo/", headers=h1)
+    res2 = client.get("/todo/", headers=h2)
+
+    assert len(res1.json()) == 2
+    assert len(res2.json()) == 1
+    assert all(t["user_id"] == id1 for t in res1.json())
+    assert all(t["user_id"] == id2 for t in res2.json())
+


### PR DESCRIPTION
## Summary
- link todos to users with a `user_id` FK
- add JWT-based `get_current_user` dependency
- secure `/todo` CRUD endpoints
- filter todos by current user in CRUD
- update API schemas and tests for authenticated todo usage

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686281a991508323b2aa388dc647a0a3