### PR TITLE
Refresh DB objects on update

### DIFF
--- a/app/crud/determinazione.py
+++ b/app/crud/determinazione.py
@@ -24,6 +24,7 @@ def update_determinazione(db: Session, determinazione_id: str, data):
     for key, value in data.dict().items():
         setattr(db_det, key, value)
     db.commit()
+    db.refresh(db_det)
     return db_det
 
 

--- a/app/crud/event.py
+++ b/app/crud/event.py
@@ -24,6 +24,7 @@ def update_event(db: Session, event_id: str, data):
     for key, value in data.dict().items():
         setattr(db_event, key, value)
     db.commit()
+    db.refresh(db_event)
     return db_event
 
 

--- a/app/crud/todo.py
+++ b/app/crud/todo.py
@@ -25,6 +25,7 @@ def update_todo(db: Session, todo_id: str, data, user: User):
     for key, value in data.dict().items():
         setattr(db_todo, key, value)
     db.commit()
+    db.refresh(db_todo)
     return db_todo
 
 

--- a/tests/test_determinazioni.py
+++ b/tests/test_determinazioni.py
@@ -26,16 +26,17 @@ def test_create_determinazione(setup_db):
 def test_update_determinazione(setup_db):
     res = client.post(
         "/determinazioni/",
-        json={"capitolo": "A", "numero": "1", "descrizione": "", "somma": 100.0, "scadenza": "2023-01-01T00:00:00"},
+        json={"capitolo": "A", "numero": "1", "descrizione": "Old", "somma": 100.0, "scadenza": "2023-01-01T00:00:00"},
     )
     det_id = res.json()["id"]
     response = client.put(
         f"/determinazioni/{det_id}",
-        json={"capitolo": "B", "numero": "1", "descrizione": "", "somma": 200.0, "scadenza": "2023-02-01T00:00:00"},
+        json={"capitolo": "B", "numero": "1", "descrizione": "New", "somma": 200.0, "scadenza": "2023-02-01T00:00:00"},
     )
     assert response.status_code == 200
-    assert response.json()["capitolo"] == "B"
-    assert "descrizione" in response.json()
+    data = response.json()
+    assert data["capitolo"] == "B"
+    assert data["descrizione"] == "New"
 
 
 def test_list_determinazioni(setup_db):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -26,7 +26,7 @@ def test_update_event(setup_db):
         "/events/",
         json={
             "titolo": "Old",
-            "descrizione": "",
+            "descrizione": "Start",
             "data_ora": "2023-01-01T09:00:00",
             "is_public": False,
         },
@@ -36,13 +36,15 @@ def test_update_event(setup_db):
         f"/events/{event_id}",
         json={
             "titolo": "New",
-            "descrizione": "",
+            "descrizione": "Updated",
             "data_ora": "2023-01-02T10:00:00",
             "is_public": True,
         },
     )
     assert response.status_code == 200
-    assert response.json()["titolo"] == "New"
+    data = response.json()
+    assert data["titolo"] == "New"
+    assert data["descrizione"] == "Updated"
 
 
 def test_list_events(setup_db):


### PR DESCRIPTION
## Summary
- refresh ORM objects on update so returned objects reflect the new state
- verify updated fields are returned in CRUD tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6863105908888323b5a9484cf31730da