### PR TITLE
Implement event visibility

### DIFF
--- a/app/crud/event.py
+++ b/app/crud/event.py
@@ -1,24 +1,28 @@
 from sqlalchemy.orm import Session
 from app.models.event import Event
+from app.models.user import User
 
 
-def create_event(db: Session, data):
-    """Insert a new :class:`Event` from the given schema."""
-    db_event = Event(**data.dict())
+def create_event(db: Session, data, user: User):
+    """Insert a new :class:`Event` for ``user`` from the given schema."""
+    db_event = Event(**data.dict(), user_id=user.id)
     db.add(db_event)
     db.commit()
     db.refresh(db_event)
     return db_event
 
 
-def get_events(db: Session):
-    """Retrieve all events from storage."""
-    return db.query(Event).all()
+def get_events(db: Session, user: User | None = None):
+    """Retrieve events visible to ``user`` (or public if ``None``)."""
+    query = db.query(Event)
+    if user is None:
+        return query.filter(Event.is_public == True).all()
+    return query.filter((Event.is_public == True) | (Event.user_id == user.id)).all()
 
 
-def update_event(db: Session, event_id: str, data):
-    """Update an ``Event`` by id or return ``None`` if missing."""
-    db_event = db.query(Event).filter(Event.id == event_id).first()
+def update_event(db: Session, event_id: str, data, user: User):
+    """Update an ``Event`` owned by ``user`` or return ``None`` if missing."""
+    db_event = db.query(Event).filter(Event.id == event_id, Event.user_id == user.id).first()
     if not db_event:
         return None
     for key, value in data.dict().items():
@@ -28,9 +32,9 @@ def update_event(db: Session, event_id: str, data):
     return db_event
 
 
-def delete_event(db: Session, event_id: str):
-    """Delete the event with ``event_id`` if it exists."""
-    db_event = db.query(Event).filter(Event.id == event_id).first()
+def delete_event(db: Session, event_id: str, user: User):
+    """Delete the event owned by ``user`` with ``event_id`` if it exists."""
+    db_event = db.query(Event).filter(Event.id == event_id, Event.user_id == user.id).first()
     if db_event:
         db.delete(db_event)
         db.commit()

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -43,3 +43,13 @@ def get_current_user(
     if not user:
         raise HTTPException(status_code=401, detail="User not found")
     return user
+
+
+def get_optional_user(
+    db: Session = Depends(get_db),
+    authorization: str | None = Header(None, alias="Authorization"),
+) -> User | None:
+    """Return the authenticated ``User`` if credentials are provided."""
+    if authorization is None:
+        return None
+    return get_current_user(db=db, authorization=authorization)

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Column, String, DateTime, Boolean
+from sqlalchemy import Column, String, DateTime, Boolean, ForeignKey
+from sqlalchemy.orm import relationship
 from app.database import Base
 import uuid
 class Event(Base):
@@ -8,3 +9,5 @@ class Event(Base):
     descrizione = Column(String, nullable=True)
     data_ora = Column(DateTime, nullable=False)
     is_public = Column(Boolean, default=False)
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    user = relationship("User", back_populates="events")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -7,4 +7,5 @@ class User(Base):
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     todos = relationship("ToDo", back_populates="user")
+    events = relationship("Event", back_populates="user")
 

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -23,7 +23,7 @@ def upcoming_events(
 
     ev_items = [
         {**EventResponse.from_orm(ev).dict(), "kind": "event"}
-        for ev in event.get_events(db)
+        for ev in event.get_events(db, current_user)
         if now <= ev.data_ora <= limit
     ]
 

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -1,29 +1,46 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from app.dependencies import get_db
+from app.dependencies import get_db, get_current_user, get_optional_user
+from app.models.user import User
 from app.schemas.event import EventCreate, EventResponse
 from app.crud import event
 router = APIRouter(prefix="/events", tags=["Events"],trailing_slash=False)
 
 @router.post("/", response_model=EventResponse)
-def create_event_route(data: EventCreate, db: Session = Depends(get_db)):
+def create_event_route(
+    data: EventCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Create a new event and return the stored model."""
-    return event.create_event(db, data)
+    return event.create_event(db, data, current_user)
 @router.get("/", response_model=list[EventResponse])
-def list_events(db: Session = Depends(get_db)):
+def list_events(
+    db: Session = Depends(get_db),
+    current_user: User | None = Depends(get_optional_user),
+):
     """Retrieve all events from the database."""
-    return event.get_events(db)
+    return event.get_events(db, current_user)
 @router.put("/{event_id}", response_model=EventResponse)
-def update_event_route(event_id: str, data: EventCreate, db: Session = Depends(get_db)):
+def update_event_route(
+    event_id: str,
+    data: EventCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Update an event by ``event_id`` or raise 404 if missing."""
-    db_event = event.update_event(db, event_id, data)
+    db_event = event.update_event(db, event_id, data, current_user)
     if not db_event:
         raise HTTPException(status_code=404, detail="Event not found")
     return db_event
 @router.delete("/{event_id}")
-def delete_event_route(event_id: str, db: Session = Depends(get_db)):
+def delete_event_route(
+    event_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Delete an event if present and confirm deletion."""
-    db_event = event.delete_event(db, event_id)
+    db_event = event.delete_event(db, event_id, current_user)
     if not db_event:
         raise HTTPException(status_code=404, detail="Event not found")
     return {"ok": True}

--- a/app/schemas/event.py
+++ b/app/schemas/event.py
@@ -7,5 +7,6 @@ class EventCreate(BaseModel):
     is_public: bool = False
 class EventResponse(EventCreate):
     id: str
+    user_id: str
     class Config:
         orm_mode = True

--- a/migrations/versions/0001_create_tables.py
+++ b/migrations/versions/0001_create_tables.py
@@ -26,6 +26,7 @@ def upgrade() -> None:
         sa.Column('descrizione', sa.String(), nullable=True),
         sa.Column('data_ora', sa.DateTime(), nullable=False),
         sa.Column('is_public', sa.Boolean(), nullable=True),
+        sa.Column('user_id', sa.String(), sa.ForeignKey('users.id'), nullable=False),
     )
     op.create_index('ix_events_id', 'events', ['id'])
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -31,6 +31,7 @@ def test_dashboard_upcoming(monkeypatch, setup_db):
             "data_ora": (now + timedelta(days=1)).isoformat(),
             "is_public": True,
         },
+        headers=headers,
     )
     client.post(
         "/events/",
@@ -40,6 +41,7 @@ def test_dashboard_upcoming(monkeypatch, setup_db):
             "data_ora": (now + timedelta(days=8)).isoformat(),
             "is_public": True,
         },
+        headers=headers,
     )
 
     client.post(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7,21 +7,31 @@ from app.main import app
 
 client = TestClient(app)
 
+
+def auth_user(email: str):
+    resp = client.post("/users/", json={"email": email, "password": "secret"})
+    user_id = resp.json()["id"]
+    token = client.post("/login", json={"email": email, "password": "secret"}).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}, user_id
+
 def test_create_event(setup_db):
+    headers, user_id = auth_user("ev@example.com")
     data = {
         "titolo": "Meeting",
         "descrizione": "Desc",
         "data_ora": "2023-01-01T09:00:00",
         "is_public": True,
     }
-    response = client.post("/events/", json=data)
+    response = client.post("/events/", json=data, headers=headers)
     assert response.status_code == 200
     body = response.json()
     assert body["titolo"] == "Meeting"
+    assert body["user_id"] == user_id
     assert "id" in body
 
 
 def test_update_event(setup_db):
+    headers, _ = auth_user("edit@example.com")
     res = client.post(
         "/events/",
         json={
@@ -30,6 +40,7 @@ def test_update_event(setup_db):
             "data_ora": "2023-01-01T09:00:00",
             "is_public": False,
         },
+        headers=headers,
     )
     event_id = res.json()["id"]
     response = client.put(
@@ -40,6 +51,7 @@ def test_update_event(setup_db):
             "data_ora": "2023-01-02T10:00:00",
             "is_public": True,
         },
+        headers=headers,
     )
     assert response.status_code == 200
     data = response.json()
@@ -48,26 +60,41 @@ def test_update_event(setup_db):
 
 
 def test_list_events(setup_db):
+    h1, _ = auth_user("a@example.com")
+    h2, _ = auth_user("b@example.com")
     client.post(
         "/events/",
         json={"titolo": "A", "descrizione": "", "data_ora": "2023-01-01T09:00:00", "is_public": False},
+        headers=h1,
     )
     client.post(
         "/events/",
         json={"titolo": "B", "descrizione": "", "data_ora": "2023-01-02T09:00:00", "is_public": False},
+        headers=h2,
     )
-    response = client.get("/events/")
-    assert response.status_code == 200
-    assert len(response.json()) == 2
+    client.post(
+        "/events/",
+        json={"titolo": "Pub", "descrizione": "", "data_ora": "2023-01-03T09:00:00", "is_public": True},
+        headers=h2,
+    )
+    res1 = client.get("/events/", headers=h1)
+    res2 = client.get("/events/", headers=h2)
+    res3 = client.get("/events/")
+    assert len(res1.json()) == 2
+    assert len(res2.json()) == 2
+    assert len(res3.json()) == 1
 
 
 def test_delete_event(setup_db):
+    headers, _ = auth_user("del@example.com")
     res = client.post(
         "/events/",
         json={"titolo": "A", "descrizione": "", "data_ora": "2023-01-01T09:00:00", "is_public": False},
+        headers=headers,
     )
     event_id = res.json()["id"]
-    response = client.delete(f"/events/{event_id}")
+    response = client.delete(f"/events/{event_id}", headers=headers)
     assert response.status_code == 200
     assert response.json()["ok"] is True
-    assert client.get("/events/").json() == []
+    assert client.get("/events/", headers=headers).json() == []
+


### PR DESCRIPTION
## Summary
- add user ownership to events with `user_id` column and relationship
- ensure events are created, updated, and deleted only by authenticated users
- filter event listings so private events are visible only to their owner
- expose optional user dependency for open endpoints
- update dashboard and tests for new behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6863deed9488832390b53df6df48798e