### PR TITLE
Fix FastAPI APIRouter changes

### DIFF
--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -9,7 +9,7 @@ from app.schemas.todo import ToDoResponse
 from app.crud import event, todo
 from app.services.google_calendar import list_upcoming_events
 
-router = APIRouter(prefix="/dashboard", tags=["Dashboard"], trailing_slash=False)
+router = APIRouter(prefix="/dashboard", tags=["Dashboard"])
 
 
 @router.get("/upcoming")

--- a/app/routes/determinazioni.py
+++ b/app/routes/determinazioni.py
@@ -4,7 +4,7 @@ from app.dependencies import get_db
 from app.schemas.determinazione import DeterminazioneCreate, DeterminazioneResponse
 from app.crud import determinazione
 
-router = APIRouter(prefix="/determinazioni", tags=["Determinazioni"],trailing_slash=False)
+router = APIRouter(prefix="/determinazioni", tags=["Determinazioni"])
 
 @router.post("/", response_model=DeterminazioneResponse)
 def create_determinazione_route(data: DeterminazioneCreate, db: Session = Depends(get_db)):

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -4,7 +4,7 @@ from app.dependencies import get_db, get_current_user, get_optional_user
 from app.models.user import User
 from app.schemas.event import EventCreate, EventResponse
 from app.crud import event
-router = APIRouter(prefix="/events", tags=["Events"],trailing_slash=False)
+router = APIRouter(prefix="/events", tags=["Events"])
 
 @router.post("/", response_model=EventResponse)
 def create_event_route(

--- a/app/routes/pdfs.py
+++ b/app/routes/pdfs.py
@@ -7,7 +7,7 @@ from app.schemas.pdffile import PDFFileCreate, PDFFileResponse
 from app.crud import pdffile as crud_pdffile
 import os
 
-router = APIRouter(prefix="/pdf", tags=["PDF"], trailing_slash=False)
+router = APIRouter(prefix="/pdf", tags=["PDF"])
 
 
 @router.get("", response_model=List[PDFFileResponse])

--- a/app/routes/todo.py
+++ b/app/routes/todo.py
@@ -5,7 +5,7 @@ from app.models.user import User
 from app.schemas.todo import ToDoCreate, ToDoResponse
 from app.crud import todo
 
-router = APIRouter(prefix="/todo", tags=["ToDo"],trailing_slash=False)
+router = APIRouter(prefix="/todo", tags=["ToDo"])
 
 @router.post("/", response_model=ToDoResponse)
 def create_todo_route(


### PR DESCRIPTION
## Summary
- update routers to remove `trailing_slash` parameter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6863f5d0c02c8323aa80fdce4a5cba94