### PR TITLE
Fix missing python-multipart dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ psycopg2-binary
 pytest
 httpx
 alembic
+python-multipart


### PR DESCRIPTION
## Summary
- add `python-multipart` to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6863f91552988323867a947bc69346b1