### PR TITLE
Fix redirect slashes behavior

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.database import Base, engine
 from app.routes import users, auth, events, todo, determinazioni, pdfs, dashboard
 
-app = FastAPI(redirect_slashes=False)
+# Enable automatic redirect so both `/path` and `/path/` work
+# Tests continue to use the canonical routes defined in the routers
+app = FastAPI()
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Summary
- allow FastAPI to redirect between `/path` and `/path/`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6863fed16c1083239d3ec17120231551