### PR TITLE
Update pdf endpoints with trailing slash

### DIFF
--- a/app/routes/pdfs.py
+++ b/app/routes/pdfs.py
@@ -10,12 +10,12 @@ import os
 router = APIRouter(prefix="/pdf", tags=["PDF"])
 
 
-@router.get("", response_model=List[PDFFileResponse])
+@router.get("/", response_model=List[PDFFileResponse])
 def list_pdfs(db: Session = Depends(get_db)):
     return crud_pdffile.get_multi(db)
 
 
-@router.post("", response_model=PDFFileResponse, status_code=201)
+@router.post("/", response_model=PDFFileResponse, status_code=201)
 async def upload_pdf(
     title: str = Form(...),
     file: UploadFile = File(...),

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -13,7 +13,7 @@ def test_upload_pdf_and_list(setup_db, tmp_path):
     pdf_path.write_bytes(b"%PDF-1.4 test")
     with open(pdf_path, "rb") as fh:
         res = client.post(
-            "/pdf",
+            "/pdf/",
             data={"title": "Doc"},
             files={"file": ("sample.pdf", fh, "application/pdf")},
         )
@@ -22,7 +22,7 @@ def test_upload_pdf_and_list(setup_db, tmp_path):
     assert body["title"] == "Doc"
     assert "filename" in body
 
-    list_res = client.get("/pdf")
+    list_res = client.get("/pdf/")
     assert list_res.status_code == 200
     assert len(list_res.json()) == 1
 
@@ -36,7 +36,7 @@ def test_upload_invalid_content_type(setup_db, tmp_path):
     txt_path.write_text("hello")
     with open(txt_path, "rb") as fh:
         res = client.post(
-            "/pdf",
+            "/pdf/",
             data={"title": "Bad"},
             files={"file": ("sample.txt", fh, "text/plain")},
         )


### PR DESCRIPTION
## Summary
- mount PDF listing and upload endpoints at `/pdf/`
- adjust tests to match new URLs

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6863fece60848323b3e69d0e9e64624e