### PR TITLE
Include orari router

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,16 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.database import Base, engine
-from app.routes import users, auth, events, todo, determinazioni, pdfs, dashboard
+from app.routes import (
+    users,
+    auth,
+    events,
+    todo,
+    determinazioni,
+    pdfs,
+    dashboard,
+)
+from app.routes.orari import router as orari_router
 
 # Enable automatic redirect so both `/path` and `/path/` work
 # Tests continue to use the canonical routes defined in the routers
@@ -28,6 +37,7 @@ app.include_router(todo.router)
 app.include_router(determinazioni.router)
 app.include_router(pdfs.router)
 app.include_router(dashboard.router)
+app.include_router(orari_router)
 
 from app.crud.pdffile import get_upload_root
 from fastapi.staticfiles import StaticFiles


### PR DESCRIPTION
## Summary
- import `orari_router` from `app.routes.orari`
- register the router on the FastAPI app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68643fbb5bf88323b73ff29f07da7d8d