### PR TITLE
Add Turno model and schemas

### DIFF
--- a/app/models/turno.py
+++ b/app/models/turno.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, String, Date, Time, ForeignKey
+from sqlalchemy.orm import relationship
+from app.database import Base
+import uuid
+
+class Turno(Base):
+    __tablename__ = "turni"
+
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    giorno = Column(Date, nullable=False)
+
+    inizio_1 = Column(Time, nullable=False)
+    fine_1 = Column(Time, nullable=False)
+    inizio_2 = Column(Time, nullable=True)
+    fine_2 = Column(Time, nullable=True)
+    inizio_3 = Column(Time, nullable=True)
+    fine_3 = Column(Time, nullable=True)
+
+    tipo = Column(String, nullable=True)
+    note = Column(String, nullable=True)
+
+    user = relationship("User", back_populates="turni")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -8,4 +8,5 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
     todos = relationship("ToDo", back_populates="user")
     events = relationship("Event", back_populates="user")
+    turni = relationship("Turno", back_populates="user")
 

--- a/app/schemas/turno.py
+++ b/app/schemas/turno.py
@@ -1,0 +1,25 @@
+from datetime import date, time
+from pydantic import BaseModel
+from typing import Optional
+
+class Slot(BaseModel):
+    inizio: time
+    fine: time
+
+class TurnoBase(BaseModel):
+    giorno: date
+    slot1: Slot
+    slot2: Optional[Slot] = None
+    slot3: Optional[Slot] = None
+    tipo: str
+    note: Optional[str] = None
+
+class TurnoIn(TurnoBase):
+    user_id: str
+
+class TurnoOut(TurnoBase):
+    id: str
+    user_id: str
+
+    class Config:
+        orm_mode = True

--- a/migrations/versions/0002_create_turni_table.py
+++ b/migrations/versions/0002_create_turni_table.py
@@ -1,0 +1,32 @@
+"""create turni table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002_create_turni_table'
+down_revision = '0001_create_tables'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'turni',
+        sa.Column('id', sa.String(), primary_key=True),
+        sa.Column('user_id', sa.String(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('giorno', sa.Date(), nullable=False),
+        sa.Column('inizio_1', sa.Time(), nullable=False),
+        sa.Column('fine_1', sa.Time(), nullable=False),
+        sa.Column('inizio_2', sa.Time(), nullable=True),
+        sa.Column('fine_2', sa.Time(), nullable=True),
+        sa.Column('inizio_3', sa.Time(), nullable=True),
+        sa.Column('fine_3', sa.Time(), nullable=True),
+        sa.Column('tipo', sa.String(), nullable=True),
+        sa.Column('note', sa.String(), nullable=True),
+    )
+    op.create_index('ix_turni_id', 'turni', ['id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_turni_id', table_name='turni')
+    op.drop_table('turni')


### PR DESCRIPTION
## Summary
- implement `Turno` ORM model
- register relationship on `User`
- add Pydantic schemas for turni
- add Alembic migration for `turni` table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68643fb86d0883238c6c30a7b6eac892