### PR TITLE
Update calendar env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 PDF_UPLOAD_ROOT=uploads/pdfs
 GOOGLE_CREDENTIALS_JSON=/etc/keys/service_account.json
+G_EVENT_CAL_ID=eventi_pl@group.calendar.google.com      # calendario Eventi
 G_SHIFT_CAL_ID=turni_pl@group.calendar.google.com      # calendario Turni
 
 GOOGLE_CALENDAR_ID=

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 - `PDF_UPLOAD_ROOT` – directory where uploaded PDF files are stored.
 - `GOOGLE_CREDENTIALS_JSON` – JSON credentials (or path) for Google APIs.
 - `GOOGLE_CALENDAR_ID` – ID of the calendar to read events from.
+- `G_EVENT_CAL_ID` – ID of the Google Calendar used for event syncs.
+- `G_SHIFT_CAL_ID` – ID of the Google Calendar used for shift syncs.
 
 ## Database migrations
 


### PR DESCRIPTION
## Summary
- document `G_EVENT_CAL_ID` and `G_SHIFT_CAL_ID`
- add an example value for `G_EVENT_CAL_ID`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68643fbc36008323b9d22004d32d2fbc