### PR TITLE
Add turni tests and implementation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,16 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.database import Base, engine
-from app.routes import users, auth, events, todo, determinazioni, pdfs, dashboard
+from app.routes import (
+    users,
+    auth,
+    events,
+    todo,
+    determinazioni,
+    pdfs,
+    dashboard,
+    turni,
+)
 
 # Enable automatic redirect so both `/path` and `/path/` work
 # Tests continue to use the canonical routes defined in the routers
@@ -27,6 +36,7 @@ app.include_router(events.router)
 app.include_router(todo.router)
 app.include_router(determinazioni.router)
 app.include_router(pdfs.router)
+app.include_router(turni.router)
 app.include_router(dashboard.router)
 
 from app.crud.pdffile import get_upload_root

--- a/app/models/turno.py
+++ b/app/models/turno.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, String, Date, Time, ForeignKey
+from sqlalchemy.orm import relationship
+import uuid
+
+from app.database import Base
+
+class Turno(Base):
+    __tablename__ = "turni"
+
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    giorno = Column(Date, nullable=False)
+
+    inizio_1 = Column(Time, nullable=False)
+    fine_1 = Column(Time, nullable=False)
+    inizio_2 = Column(Time, nullable=True)
+    fine_2 = Column(Time, nullable=True)
+    inizio_3 = Column(Time, nullable=True)
+    fine_3 = Column(Time, nullable=True)
+
+    tipo = Column(String, nullable=False)
+    note = Column(String, nullable=True)
+
+    user = relationship("User", back_populates="turni")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -8,4 +8,5 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
     todos = relationship("ToDo", back_populates="user")
     events = relationship("Event", back_populates="user")
+    turni = relationship("Turno", back_populates="user")
 

--- a/app/routes/turni.py
+++ b/app/routes/turni.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db, get_current_user
+from app.models.user import User
+from app.schemas.turno import TurnoIn, TurnoResponse
+from app.crud import turno as crud_turno
+
+router = APIRouter(prefix="/turni", tags=["Turni"])
+
+
+@router.post("/", response_model=TurnoResponse)
+def upsert_turno_route(
+    data: TurnoIn,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if data.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return crud_turno.upsert_turno(db, data)
+
+
+@router.delete("/{turno_id}")
+def delete_turno_route(
+    turno_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    crud_turno.remove_turno(db, turno_id)
+    return {"ok": True}

--- a/app/schemas/turno.py
+++ b/app/schemas/turno.py
@@ -1,0 +1,21 @@
+from datetime import date, time
+from pydantic import BaseModel
+
+class Slot(BaseModel):
+    inizio: time
+    fine: time
+
+class TurnoIn(BaseModel):
+    user_id: str
+    giorno: date
+    slot1: Slot
+    slot2: Slot | None = None
+    slot3: Slot | None = None
+    tipo: str = "NORMALE"
+    note: str | None = None
+
+class TurnoResponse(TurnoIn):
+    id: str
+
+    class Config:
+        orm_mode = True

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -1,0 +1,69 @@
+import os
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def auth_user(email: str):
+    resp = client.post("/users/", json={"email": email, "password": "secret"})
+    user_id = resp.json()["id"]
+    token = client.post(
+        "/login",
+        json={"email": email, "password": "secret"},
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}, user_id
+
+
+def base_payload(user_id: str):
+    return {
+        "user_id": user_id,
+        "giorno": "2023-01-01",
+        "slot1": {"inizio": "08:00:00", "fine": "12:00:00"},
+        "tipo": "NORMALE",
+        "note": "test",
+    }
+
+
+def test_create_turno(monkeypatch, setup_db):
+    headers, user_id = auth_user("turno_create@example.com")
+    monkeypatch.setattr("app.services.gcal.sync_shift_event", lambda turno: None)
+    payload = base_payload(user_id)
+    res = client.post("/turni/", json=payload, headers=headers)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["user_id"] == user_id
+    assert body["tipo"] == "NORMALE"
+    assert "id" in body
+
+
+def test_update_turno(monkeypatch, setup_db):
+    headers, user_id = auth_user("turno_update@example.com")
+    monkeypatch.setattr("app.services.gcal.sync_shift_event", lambda turno: None)
+    first = client.post("/turni/", json=base_payload(user_id), headers=headers)
+    turno_id = first.json()["id"]
+    update_payload = base_payload(user_id)
+    update_payload["slot1"] = {"inizio": "09:00:00", "fine": "13:00:00"}
+    update_payload["tipo"] = "STRAORD"
+    res = client.post("/turni/", json=update_payload, headers=headers)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["id"] == turno_id
+    assert data["tipo"] == "STRAORD"
+    assert data["inizio_1"] == "09:00:00"
+
+
+def test_delete_turno(monkeypatch, setup_db):
+    headers, user_id = auth_user("turno_delete@example.com")
+    monkeypatch.setattr("app.services.gcal.sync_shift_event", lambda turno: None)
+    monkeypatch.setattr("app.services.gcal.delete_shift_event", lambda tid: None)
+    create = client.post("/turni/", json=base_payload(user_id), headers=headers)
+    turno_id = create.json()["id"]
+    res = client.delete(f"/turni/{turno_id}", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["ok"] is True
+    res2 = client.delete(f"/turni/{turno_id}", headers=headers)
+    assert res2.status_code == 404


### PR DESCRIPTION
## Summary
- support turni management by adding model, schema and routes
- register new router in the app
- add integration tests for turni operations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68643fbf0b7c8323b955bc2203339b18