### PR TITLE
Implement orari endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.database import Base, engine
-from app.routes import users, auth, events, todo, determinazioni, pdfs, dashboard
+from app.routes import users, auth, events, todo, determinazioni, pdfs, dashboard, orari
 
 # Enable automatic redirect so both `/path` and `/path/` work
 # Tests continue to use the canonical routes defined in the routers
@@ -28,6 +28,7 @@ app.include_router(todo.router)
 app.include_router(determinazioni.router)
 app.include_router(pdfs.router)
 app.include_router(dashboard.router)
+app.include_router(orari.router)
 
 from app.crud.pdffile import get_upload_root
 from fastapi.staticfiles import StaticFiles

--- a/app/models/turno.py
+++ b/app/models/turno.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, String, Date, Time, ForeignKey
+from sqlalchemy.orm import relationship
+from app.database import Base
+import uuid
+
+
+class Turno(Base):
+    __tablename__ = "turni"
+
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    giorno = Column(Date, nullable=False)
+
+    inizio_1 = Column(Time, nullable=False)
+    fine_1 = Column(Time, nullable=False)
+    inizio_2 = Column(Time, nullable=True)
+    fine_2 = Column(Time, nullable=True)
+    inizio_3 = Column(Time, nullable=True)
+    fine_3 = Column(Time, nullable=True)
+
+    tipo = Column(String, nullable=False)
+    note = Column(String, nullable=True)
+
+    user = relationship("User", back_populates="turni")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -8,4 +8,5 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
     todos = relationship("ToDo", back_populates="user")
     events = relationship("Event", back_populates="user")
+    turni = relationship("Turno", back_populates="user")
 

--- a/app/routes/orari.py
+++ b/app/routes/orari.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from app.schemas.turno import TurnoIn, TurnoOut
+from app.crud import turno as crud
+
+router = APIRouter(prefix="/orari", tags=["Orari"])
+
+
+@router.post("/", response_model=TurnoOut)
+def save_turno(payload: TurnoIn, db: Session = Depends(get_db)):
+    """Create or update a shift record."""
+    return crud.upsert_turno(db, payload)
+
+
+@router.delete("/{turno_id}")
+def delete_turno(turno_id: UUID, db: Session = Depends(get_db)):
+    """Remove a shift by id."""
+    crud.remove_turno(db, turno_id)
+    return {"ok": True}

--- a/app/schemas/turno.py
+++ b/app/schemas/turno.py
@@ -1,0 +1,28 @@
+from datetime import date, time
+from pydantic import BaseModel
+
+
+class ShiftSlot(BaseModel):
+    inizio: time
+    fine: time
+
+
+class TurnoBase(BaseModel):
+    user_id: str
+    giorno: date
+    slot1: ShiftSlot
+    slot2: ShiftSlot | None = None
+    slot3: ShiftSlot | None = None
+    tipo: str = "NORMALE"
+    note: str | None = None
+
+
+class TurnoIn(TurnoBase):
+    pass
+
+
+class TurnoOut(TurnoBase):
+    id: str
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add Turno model and schemas
- expose `/orari` endpoints for saving and deleting shifts
- wire new router into application

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68643fba04ec8323bdca0fac0890030a