### PR TITLE
Add orari endpoints

### DIFF
--- a/app/routes/orari.py
+++ b/app/routes/orari.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from app.schemas.turno import TurnoIn, TurnoOut
+from app.crud import turno as crud_turno
+
+router = APIRouter(prefix="/orari", tags=["Orari"])
+
+@router.post("", response_model=TurnoOut)
+def save_turno(payload: TurnoIn, db: Session = Depends(get_db)):
+    """Create or update a turno."""
+    return crud_turno.upsert_turno(db, payload)
+
+@router.delete("/{turno_id}")
+def delete_turno(turno_id: str, db: Session = Depends(get_db)):
+    """Delete a turno."""
+    crud_turno.remove_turno(db, turno_id)
+    return {"ok": True}
+


### PR DESCRIPTION
## Summary
- implement API for storing and removing `Turno` records via `/orari`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686441400b088323913b72c5fcd15803