### PR TITLE
Add Turni routes

### DIFF
--- a/app/crud/turno.py
+++ b/app/crud/turno.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from fastapi import HTTPException, status
 
 from app.models.turno import Turno          # modello ORM
+from app.models.user import User
 from app.schemas.turno import TurnoIn       # Pydantic (input)
 from app.services.gcal import (
     sync_shift_event,
@@ -81,3 +82,14 @@ def remove_turno(db: Session, turno_id: UUID) -> None:
             detail="Turno non trovato",
         )
     db.commit()
+
+
+# ------------------------------------------------------------------------------
+def get_turni(db: Session, user: User) -> list[Turno]:
+    """Return all ``Turno`` records for ``user`` ordered by date."""
+    return (
+        db.query(Turno)
+        .filter(Turno.user_id == user.id)
+        .order_by(Turno.giorno.asc())
+        .all()
+    )

--- a/app/routes/orari.py
+++ b/app/routes/orari.py
@@ -1,20 +1,39 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from app.dependencies import get_db
+from app.dependencies import get_db, get_current_user
+from app.models.user import User
 from app.schemas.turno import TurnoIn, TurnoOut
 from app.crud import turno as crud_turno
 
-router = APIRouter(prefix="/orari", tags=["Orari"])
+router = APIRouter(prefix="/orari", tags=["Turni"])
 
-@router.post("", response_model=TurnoOut)
-def save_turno(payload: TurnoIn, db: Session = Depends(get_db)):
+
+@router.post("/", response_model=TurnoOut)
+def save_turno(
+    payload: TurnoIn,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Create or update a turno."""
     return crud_turno.upsert_turno(db, payload)
 
+
+@router.get("/", response_model=list[TurnoOut])
+def list_turni(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List turni for the authenticated user."""
+    return crud_turno.get_turni(db, current_user)
+
+
 @router.delete("/{turno_id}")
-def delete_turno(turno_id: str, db: Session = Depends(get_db)):
+def delete_turno(
+    turno_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Delete a turno."""
     crud_turno.remove_turno(db, turno_id)
     return {"ok": True}
-


### PR DESCRIPTION
## Summary
- implement turni listing in CRUD layer
- rewrite `orari` router with auth dependencies and list endpoint
- include router in `main`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686444978ff08323bcab2b3ee409078b