### PR TITLE
Implement global shift listing

### DIFF
--- a/app/crud/turno.py
+++ b/app/crud/turno.py
@@ -92,3 +92,13 @@ def get_turni(db: Session, user: User) -> list[Turno]:
         .order_by(Turno.giorno.asc())
         .all()
     )
+
+
+# ------------------------------------------------------------------------------
+def list_all(db: Session) -> list[Turno]:
+    """Return all ``Turno`` records in the database ordered by date."""
+    return (
+        db.query(Turno)
+        .order_by(Turno.giorno.asc())
+        .all()
+    )

--- a/app/routes/orari.py
+++ b/app/routes/orari.py
@@ -24,8 +24,8 @@ def list_turni(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """List turni for the authenticated user."""
-    return crud_turno.get_turni(db, current_user)
+    """Return all turni without filtering by user."""
+    return crud_turno.list_all(db)
 
 
 @router.delete("/{turno_id}")


### PR DESCRIPTION
## Summary
- add `list_all` to the turno CRUD module
- expose all shifts via GET `/orari/`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686520f64c9883239105e47df140a157