### PR TITLE
Add Excel import endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.routes import (
     dashboard,
 )
 from app.routes.orari import router as orari_router
+from app.routes import import_xlsx
 
 # Enable automatic redirect so both `/path` and `/path/` work
 # Tests continue to use the canonical routes defined in the routers
@@ -38,6 +39,7 @@ app.include_router(determinazioni.router)
 app.include_router(pdfs.router)
 app.include_router(dashboard.router)
 app.include_router(orari_router)
+app.include_router(import_xlsx.router)
 
 from app.crud.pdffile import get_upload_root
 from fastapi.staticfiles import StaticFiles

--- a/app/routes/import_xlsx.py
+++ b/app/routes/import_xlsx.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, UploadFile, Depends
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+import tempfile
+
+from app.dependencies import get_db
+from app.schemas.turno import TurnoIn
+from app.crud import turno as crud_turno
+from app.services.excel_import import parse_excel, df_to_pdf
+
+router = APIRouter(prefix="/import", tags=["Import"])
+
+
+@router.post("/xlsx")
+async def import_xlsx(
+    file: UploadFile,
+    db: Session = Depends(get_db),
+):
+    """Import Excel shifts, sync them and return a PDF summary."""
+    # 1 – save temp file
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
+        tmp.write(await file.read())
+        tmp_path = tmp.name
+
+    # 2 – parse Excel -> TurnoIn payloads
+    rows = parse_excel(tmp_path)
+
+    # 3 – store/update each shift (DB + Google Calendar)
+    for payload in rows:
+        crud_turno.upsert_turno(db, TurnoIn(**payload))
+
+    # 4 – generate PDF summary
+    pdf_path = df_to_pdf(rows)
+    return FileResponse(pdf_path, filename="turni_settimana.pdf")

--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import pdfkit
+import tempfile
+from typing import List, Dict, Any
+
+
+def parse_excel(path: str) -> List[Dict[str, Any]]:
+    """Parse an Excel file into TurnoIn-compatible payloads."""
+    df = pd.read_excel(path)  # requires openpyxl
+    rows: list[dict[str, Any]] = []
+    for _, row in df.iterrows():
+        payload: dict[str, Any] = {
+            "user_id": str(row["User ID"]),
+            "giorno": row["Data"].date() if hasattr(row["Data"], "date") else row["Data"],
+            "slot1": {"inizio": row["Inizio1"], "fine": row["Fine1"]},
+            "tipo": row.get("Tipo", "NORMALE"),
+            "note": row.get("Note", ""),
+        }
+        if not pd.isna(row.get("Inizio2")) and not pd.isna(row.get("Fine2")):
+            payload["slot2"] = {"inizio": row["Inizio2"], "fine": row["Fine2"]}
+        if not pd.isna(row.get("Inizio3")) and not pd.isna(row.get("Fine3")):
+            payload["slot3"] = {"inizio": row["Inizio3"], "fine": row["Fine3"]}
+        rows.append(payload)
+    return rows
+
+
+def df_to_pdf(rows: List[Dict[str, Any]]) -> str:
+    """Generate a PDF table from row payloads and return its path."""
+    df = pd.DataFrame(rows)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as tmp_html:
+        df.to_html(tmp_html.name, index=False)
+        html_path = tmp_html.name
+    pdf_path = html_path.replace(".html", ".pdf")
+    pdfkit.from_file(html_path, pdf_path)  # requires wkhtmltopdf installed
+    return pdf_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ alembic
 python-multipart
 google-api-python-client
 google-auth
+pandas>=2.0.0
+openpyxl>=3.1.2
+pdfkit>=1.0.0


### PR DESCRIPTION
## Summary
- add `/import/xlsx` route for uploading Excel files with shifts
- implement Excel parsing and PDF generation utilities
- include router in main app
- require pandas, openpyxl and pdfkit packages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686525748bf88323aba327b8971535d8