### PR TITLE
Adjust events creation status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ GET /dashboard/upcoming?days=5
 The response is a chronologically ordered list where each item contains a
 `kind` field (`event`, `todo` or `google`) and a `data_ora` timestamp.
 
+## Events endpoint
+
+Creating an event via `POST /events/` now returns HTTP status code `201` along
+with the created event.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -6,7 +6,7 @@ from app.schemas.event import EventCreate, EventResponse
 from app.crud import event
 router = APIRouter(prefix="/events", tags=["Events"])
 
-@router.post("/", response_model=EventResponse)
+@router.post("/", response_model=EventResponse, status_code=201)
 def create_event_route(
     data: EventCreate,
     db: Session = Depends(get_db),

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -23,7 +23,7 @@ def test_create_event(setup_db):
         "is_public": True,
     }
     response = client.post("/events/", json=data, headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == 201
     body = response.json()
     assert body["titolo"] == "Meeting"
     assert body["user_id"] == user_id


### PR DESCRIPTION
## Summary
- return HTTP 201 when creating events
- adjust event tests to expect 201
- document events endpoint status code in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_686526a37f948323bd12ee577441622e