### PR TITLE
Compute timezone offset dynamically

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -10,7 +10,7 @@ Richiede:
 """
 
 import os
-from datetime import date, time
+from datetime import date, time, datetime
 from functools import lru_cache
 
 from google.oauth2 import service_account
@@ -34,7 +34,14 @@ SHIFT_CAL_ID = os.getenv("G_SHIFT_CAL_ID")   # nuovo calendario “Turni di Serv
 # ------------------------------------------------------------------- utilità
 def iso_dt(d: date, t: time) -> str:
     """2025-07-01 + 08:30 -> '2025-07-01T08:30:00+02:00'"""
-    tz = "+02:00"  # forza fuso orario locale; se serve, calcolalo dinamicamente
+    offset = datetime.now().astimezone().utcoffset()
+    if offset is None:
+        tz = "+00:00"
+    else:
+        total_minutes = int(offset.total_seconds() // 60)
+        sign = "+" if total_minutes >= 0 else "-"
+        h, m = divmod(abs(total_minutes), 60)
+        tz = f"{sign}{h:02d}:{m:02d}"
     return f"{d.isoformat()}T{t.strftime('%H:%M')}:00{tz}"
 
 def first_non_null(*vals):

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -1,0 +1,38 @@
+import types
+from datetime import date, time, timedelta
+
+from app.services import gcal
+
+
+def test_iso_dt_current_offset():
+    d = date(2023, 7, 1)
+    t = time(8, 30)
+    result = gcal.iso_dt(d, t)
+    offset = gcal.datetime.now().astimezone().utcoffset()
+    if offset is None:
+        expected = "+00:00"
+    else:
+        minutes = int(offset.total_seconds() // 60)
+        sign = "+" if minutes >= 0 else "-"
+        h, m = divmod(abs(minutes), 60)
+        expected = f"{sign}{h:02d}:{m:02d}"
+    assert result.endswith(expected)
+
+
+def test_iso_dt_uses_patched_timezone(monkeypatch):
+    class DummyNow:
+        def astimezone(self):
+            class DummyOffset:
+                def utcoffset(self, *args, **kwargs):
+                    return timedelta(hours=9, minutes=30)
+            return DummyOffset()
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            return DummyNow()
+
+    monkeypatch.setattr(gcal, "datetime", DummyDateTime)
+
+    res = gcal.iso_dt(date(2023, 1, 1), time(0, 0))
+    assert res.endswith("+09:30")


### PR DESCRIPTION
## Summary
- calculate timezone offset at runtime in `iso_dt`
- add unit tests for timezone handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686526a08c2c832383161f6ee1cf74d9