### PR TITLE
Update setup docs for wkhtmltopdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This repository contains a FastAPI backend used by Segretaria Digitale.
    ```
 3. Copy `.env.example` to `.env` and adjust the values as needed.
 
+4. Install [wkhtmltopdf](https://wkhtmltopdf.org/downloads.html) to enable
+   PDF generation in `app/services/excel_import.py`.
+
 If asynchronous database access becomes necessary later on, add `asyncpg` to
 `requirements.txt` and configure SQLAlchemy with its async engine.
 


### PR DESCRIPTION
## Summary
- mention wkhtmltopdf installation in README setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68652b3335b483239bbc7bd226e7131c