### PR TITLE
Improve Excel import docstring

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -5,7 +5,14 @@ from typing import List, Dict, Any
 
 
 def parse_excel(path: str) -> List[Dict[str, Any]]:
-    """Parse an Excel file into TurnoIn-compatible payloads."""
+    """Parse an Excel file into TurnoIn-compatible payloads.
+
+    Colonne obbligatorie / Required columns: ``Data``, ``User ID``,
+    ``Inizio1`` e ``Fine1``. Colonne facoltative / Optional: ``Inizio2``,
+    ``Fine2``, ``Inizio3``, ``Fine3``, ``Tipo`` e ``Note``.
+
+    :return: a list of dictionaries ready for the TurnoIn API.
+    """
     df = pd.read_excel(path)  # requires openpyxl
     rows: list[dict[str, Any]] = []
     for _, row in df.iterrows():


### PR DESCRIPTION
## Summary
- clarify required spreadsheet fields in `parse_excel` docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68652b48cba08323855326cbe3bc8f47