### PR TITLE
Add wkhtmltopdf to CI and docs

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -32,6 +32,9 @@ jobs:
       with:
         python-version: '3.11'
 
+    - name: Install wkhtmltopdf
+      run: sudo apt-get update && sudo apt-get install -y wkhtmltopdf
+
     - name: Install dependencies
       run: pip install -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ The response is a chronologically ordered list where each item contains a
 Creating an event via `POST /events/` now returns HTTP status code `201` along
 with the created event.
 
+## Deployment
+
+The project is deployed to **Render** using the workflow at
+`.github/workflows/deploy-backend.yml`. The workflow installs `wkhtmltopdf` so
+that PDF generation via `pdfkit` works correctly. When deploying in your own
+environment make sure to install `wkhtmltopdf` before running `pip install`:
+
+```bash
+sudo apt-get update && sudo apt-get install -y wkhtmltopdf
+pip install -r requirements.txt
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- install wkhtmltopdf in CI
- document Render deployment and wkhtmltopdf requirement

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68652b5c8d2c832398aa8f2e4ab59ecb