### PR TITLE
Clean up temp files after import

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -1,7 +1,8 @@
+import os
 import pandas as pd
 import pdfkit
 import tempfile
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 
 
 def parse_excel(path: str) -> List[Dict[str, Any]]:
@@ -24,12 +25,18 @@ def parse_excel(path: str) -> List[Dict[str, Any]]:
     return rows
 
 
-def df_to_pdf(rows: List[Dict[str, Any]]) -> str:
-    """Generate a PDF table from row payloads and return its path."""
+def df_to_pdf(rows: List[Dict[str, Any]]) -> Tuple[str, str]:
+    """Generate a PDF table from row payloads.
+
+    Returns a tuple with the PDF path and the temporary HTML path used during
+    conversion. Both files are created with ``delete=False`` so that they can be
+    cleaned up later by the caller.
+    """
     df = pd.DataFrame(rows)
     with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as tmp_html:
         df.to_html(tmp_html.name, index=False)
         html_path = tmp_html.name
-    pdf_path = html_path.replace(".html", ".pdf")
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp_pdf:
+        pdf_path = tmp_pdf.name
     pdfkit.from_file(html_path, pdf_path)  # requires wkhtmltopdf installed
-    return pdf_path
+    return pdf_path, html_path


### PR DESCRIPTION
## Summary
- ensure temporary Excel/PDF/HTML files are removed after sending the PDF
- store PDF/HTML in temp files and schedule cleanup
- test that import temp files are deleted

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68652b5b4a6483239410a9efa03d6e6a