### PR TITLE
Fix Excel cleanup

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -25,10 +25,7 @@ async def import_xlsx(
         tmp_path = tmp.name
 
     # 2 – parse Excel -> TurnoIn payloads
-    try:
-        rows = parse_excel(tmp_path)
-    finally:
-        os.remove(tmp_path)
+    rows = parse_excel(tmp_path)
 
     # 3 – store/update each shift (DB + Google Calendar)
     for payload in rows:
@@ -37,4 +34,5 @@ async def import_xlsx(
     # 4 – generate PDF summary
     pdf_path = df_to_pdf(rows)
     background_tasks.add_task(os.remove, pdf_path)
+    background_tasks.add_task(os.remove, tmp_path)
     return FileResponse(pdf_path, filename="turni_settimana.pdf")


### PR DESCRIPTION
## Summary
- schedule Excel cleanup as a background task
- remove try/finally around `parse_excel`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68652db030c88323977621c6889472d6