### PR TITLE
Return html path from df_to_pdf

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -35,6 +35,7 @@ async def import_xlsx(
         crud_turno.upsert_turno(db, TurnoIn(**payload))
 
     # 4 – generate PDF summary
-    pdf_path = df_to_pdf(rows)
+    pdf_path, html_path = df_to_pdf(rows)
     background_tasks.add_task(os.remove, pdf_path)
+    background_tasks.add_task(os.remove, html_path)
     return FileResponse(pdf_path, filename="turni_settimana.pdf")

--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pdfkit
 import tempfile
 import os
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 
 
 def parse_excel(path: str) -> List[Dict[str, Any]]:
@@ -32,15 +32,12 @@ def parse_excel(path: str) -> List[Dict[str, Any]]:
     return rows
 
 
-def df_to_pdf(rows: List[Dict[str, Any]]) -> str:
-    """Generate a PDF table from row payloads and return its path."""
+def df_to_pdf(rows: List[Dict[str, Any]]) -> Tuple[str, str]:
+    """Generate a PDF table from row payloads and return both file paths."""
     df = pd.DataFrame(rows)
     with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as tmp_html:
         df.to_html(tmp_html.name, index=False)
         html_path = tmp_html.name
     pdf_path = html_path.replace(".html", ".pdf")
-    try:
-        pdfkit.from_file(html_path, pdf_path)  # requires wkhtmltopdf installed
-    finally:
-        os.remove(html_path)
-    return pdf_path
+    pdfkit.from_file(html_path, pdf_path)  # requires wkhtmltopdf installed
+    return pdf_path, html_path


### PR DESCRIPTION
## Summary
- allow df_to_pdf to keep the HTML file and return it
- schedule HTML cleanup on /import/xlsx endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68652db2e10c8323b9baf7f68cc1731c