### PR TITLE
Implement user listing endpoint

### DIFF
--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -29,3 +29,9 @@ def get_user_by_email(db: Session, email: str):
 def verify_password(plain_password, hashed_password):
     """Return ``True`` if the plaintext password matches the hashed one."""
     return pwd_context.verify(plain_password, hashed_password)
+
+
+def list_users(db: Session):
+    """Restituisce tutti gli utenti ordinati per e-mail."""
+    from app.models.user import User  # evita import circolare
+    return db.query(User).order_by(User.email.asc()).all()

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -5,6 +5,15 @@ from app.schemas.user import UserCreate, UserResponse
 from app.crud import user
 router = APIRouter(prefix="/users", tags=["Users"])
 
+# ───── nuovo endpoint GET /users/ ─────
+@router.get("/", response_model=list[UserResponse])
+def list_users_route(
+    db: Session = Depends(get_db),
+):
+    """Restituisce la lista di tutti gli utenti."""
+    return user.list_users(db)
+# ───────────────────────────────────────
+
 @router.post("/", response_model=UserResponse)
 def create_user_route(user_data: UserCreate, db: Session = Depends(get_db)):
     """Register a new user and return it."""

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -20,3 +20,12 @@ def test_duplicate_user():
     response = client.post("/users/", json={"email": "dup@example.com", "password": "secret"})
     assert response.status_code == 409
 
+
+def test_list_users():
+    client.post("/users/", json={"email": "a@example.com", "password": "secret"})
+    client.post("/users/", json={"email": "b@example.com", "password": "secret"})
+    response = client.get("/users/")
+    assert response.status_code == 200
+    data = response.json()
+    assert [u["email"] for u in data] == ["a@example.com", "b@example.com"]
+


### PR DESCRIPTION
## Summary
- add `list_users` to user CRUD module
- expose `/users/` GET API route
- cover user list endpoint in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865397fdc2c832390d0f242ef0280c5