### PR TITLE
Add nome field to users

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -5,6 +5,7 @@ class User(Base):
     __tablename__ = "users"
     id = Column(String, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
+    nome = Column(String, nullable=False, default="", server_default="")
     hashed_password = Column(String, nullable=False)
     todos = relationship("ToDo", back_populates="user")
     events = relationship("Event", back_populates="user")

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -5,5 +5,6 @@ class UserCreate(BaseModel):
 class UserResponse(BaseModel):
     id: str
     email: str
+    nome: str
     class Config:
         orm_mode = True

--- a/migrations/versions/0003_add_nome_to_user.py
+++ b/migrations/versions/0003_add_nome_to_user.py
@@ -1,0 +1,28 @@
+"""add nome to user"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0003_add_nome_to_user'
+down_revision = '0002_create_turni_table'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('nome', sa.String(), nullable=False, server_default=''))
+    op.execute(
+        """
+        UPDATE users
+        SET nome = CASE
+            WHEN email = 'marco@comune.castione.bg.it' THEN 'Ag.Sc. Fenaroli Marco'
+            WHEN email = 'rossella@comune.castione.bg.it' THEN 'Sovr. Licini Rossella'
+            WHEN email = 'mattia@comune.castione.bg.it' THEN 'Ag.Sc. Danesi Mattia'
+            ELSE nome
+        END
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'nome')


### PR DESCRIPTION
## Summary
- add a `nome` column to User model and schema
- create Alembic migration to add/populate the column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68656221e2b88323a53631c51b88b671