### PR TITLE
Adjust tests for agent column

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -25,7 +25,7 @@ async def import_xlsx(
         tmp_path = tmp.name
 
     # 2 – parse Excel -> TurnoIn payloads
-    rows = parse_excel(tmp_path)
+    rows = parse_excel(tmp_path, db)
 
     # 3 – store/update each shift (DB + Google Calendar)
     for payload in rows:


### PR DESCRIPTION
## Summary
- update `parse_excel` to load the `Agente` column and look up the user in DB
- modify Excel import route to pass DB session to `parse_excel`
- update import tests for the new user name field and `Agente` column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68656325ec648323aaea8ce7fee4c404