### PR TITLE
Update import route to pass DB to parser

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -25,7 +25,7 @@ async def import_xlsx(
         tmp_path = tmp.name
 
     # 2 – parse Excel -> TurnoIn payloads
-    rows = parse_excel(tmp_path)
+    rows = parse_excel(tmp_path, db)
 
     # 3 – store/update each shift (DB + Google Calendar)
     for payload in rows:

--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -5,7 +5,7 @@ import os
 from typing import List, Dict, Any, Tuple
 
 
-def parse_excel(path: str) -> List[Dict[str, Any]]:
+def parse_excel(path: str, db=None) -> List[Dict[str, Any]]:
     """Parse an Excel file into TurnoIn-compatible payloads.
 
     Colonne obbligatorie / Required columns: ``Data``, ``User ID``,

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -55,7 +55,7 @@ def test_import_xlsx_creates_turni_and_returns_pdf(setup_db, tmp_path):
 def test_temp_files_removed_after_request(setup_db, tmp_path):
     captured = {}
 
-    def fake_parse_excel(path):
+    def fake_parse_excel(path, _db):
         captured['xlsx'] = path
         return []
 


### PR DESCRIPTION
## Summary
- call `parse_excel(tmp_path, db)` from the `/import/xlsx` route
- adjust tests to expect the new argument
- allow `db` parameter in `parse_excel`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68656324fe348323b9ea6ba70248d824