### PR TITLE
Update Excel import to map agent names to users

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -25,7 +25,7 @@ async def import_xlsx(
         tmp_path = tmp.name
 
     # 2 – parse Excel -> TurnoIn payloads
-    rows = parse_excel(tmp_path)
+    rows = parse_excel(db, tmp_path)
 
     # 3 – store/update each shift (DB + Google Calendar)
     for payload in rows:

--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -3,32 +3,66 @@ import pdfkit
 import tempfile
 import os
 from typing import List, Dict, Any, Tuple
+from sqlalchemy.orm import Session
 
 
-def parse_excel(path: str) -> List[Dict[str, Any]]:
-    """Parse an Excel file into TurnoIn-compatible payloads.
+def get_user_id(db: Session, agente: str) -> str:
+    """Return the ID of the user whose ``nome`` matches ``agente``.
 
-    Colonne obbligatorie / Required columns: ``Data``, ``User ID``,
-    ``Inizio1`` e ``Fine1``. Colonne facoltative / Optional: ``Inizio2``,
-    ``Fine2``, ``Inizio3``, ``Fine3``, ``Tipo`` e ``Note``.
-
-    :return: a list of dictionaries ready for the TurnoIn API.
+    The lookup is case-insensitive and ignores surrounding whitespace. If no
+    matching user is found, a ``ValueError`` is raised.
     """
+    from sqlalchemy import func
+    from app.models.user import User
+
+    record = (
+        db.query(User)
+        .filter(func.lower(User.nome) == agente.strip().lower())
+        .first()
+    )
+    if record is None:
+        raise ValueError(f"Agente '{agente}' non trovato")
+    return record.id
+
+
+def parse_excel(db: Session, path: str) -> List[Dict[str, Any]]:
+    """Parse an Excel file exported from the shift spreadsheet.
+
+    Required columns: ``Agente``, ``Data``, ``Tipo``, ``Inizio1`` and ``Fine1``.
+    Optional columns: ``Inizio2``, ``Fine2`` and ``Straordinario inizio`` /
+    ``Straordinario fine``.
+
+    The ``Agente`` value is matched against the ``nome`` field of ``User`` to
+    obtain the ``user_id`` for each row.
+
+    :param db: database session used to resolve agent names.
+    :param path: path to the Excel file to parse.
+    :return: list of dictionaries ready for the TurnoIn API.
+    """
+
     df = pd.read_excel(path)  # requires openpyxl
     rows: list[dict[str, Any]] = []
     for _, row in df.iterrows():
         payload: dict[str, Any] = {
-            "user_id": str(row["User ID"]),
+            "user_id": get_user_id(db, str(row["Agente"])),
             "giorno": row["Data"].date() if hasattr(row["Data"], "date") else row["Data"],
             "slot1": {"inizio": row["Inizio1"], "fine": row["Fine1"]},
             "tipo": row.get("Tipo", "NORMALE"),
-            "note": row.get("Note", ""),
+            "note": "",
         }
-        if not pd.isna(row.get("Inizio2")) and not pd.isna(row.get("Fine2")):
-            payload["slot2"] = {"inizio": row["Inizio2"], "fine": row["Fine2"]}
-        if not pd.isna(row.get("Inizio3")) and not pd.isna(row.get("Fine3")):
-            payload["slot3"] = {"inizio": row["Inizio3"], "fine": row["Fine3"]}
+
+        inizio2 = row.get("Inizio2")
+        fine2 = row.get("Fine2")
+        if not pd.isna(inizio2) and not pd.isna(fine2):
+            payload["slot2"] = {"inizio": inizio2, "fine": fine2}
+
+        stra_inizio = row.get("Straordinario inizio")
+        stra_fine = row.get("Straordinario fine")
+        if not pd.isna(stra_inizio) and not pd.isna(stra_fine):
+            payload["slot3"] = {"inizio": stra_inizio, "fine": stra_fine}
+
         rows.append(payload)
+
     return rows
 
 


### PR DESCRIPTION
## Summary
- implement `get_user_id` helper
- adapt `parse_excel` to new spreadsheet format using agent names
- update import route to pass DB session
- adjust tests for new format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865632410708323967d461437a885fa