### PR TITLE
Add migration for nome column

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This project uses **Alembic** to manage database schema changes. With
 alembic upgrade head
 ```
 
+After pulling the latest changes, run `alembic upgrade head` again to apply the new migration.
+
 After modifying the models, create a new revision and upgrade:
 
 ```bash

--- a/migrations/versions/0004_add_nome_column.py
+++ b/migrations/versions/0004_add_nome_column.py
@@ -1,0 +1,17 @@
+"""add nome column to users"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0004_add_nome_column'
+down_revision = '0003_add_nome_to_user'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('nome', sa.String(), nullable=False, server_default=''))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'nome')


### PR DESCRIPTION
## Summary
- add Alembic revision `0004_add_nome_column`
- mention running `alembic upgrade head` after pulling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686564c109a4832388e06076cb9c1348