### PR TITLE
Add CORS_ORIGINS env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ G_EVENT_CAL_ID=eventi_pl@group.calendar.google.com      # calendario Eventi
 G_SHIFT_CAL_ID=turni_pl@group.calendar.google.com      # calendario Turni
 
 GOOGLE_CALENDAR_ID=
+CORS_ORIGINS=https://example.com    # comma separated origins

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ This repository contains a FastAPI backend used by Segretaria Digitale.
    level (e.g. `apt-get update && apt-get install -y wkhtmltopdf`). This is
    required for PDF generation in `app/services/excel_import.py` and must be
    included in deployment build steps.
-4. Copy `.env.example` to `.env` and adjust the values as needed.
+4. Copy `.env.example` to `.env` and adjust the values as needed. If you want to
+   restrict cross-origin requests, set `CORS_ORIGINS` to a comma-separated list
+   of allowed origins; leaving it unset defaults to `"*"` for development.
 
 If asynchronous database access becomes necessary later on, add `asyncpg` to
 `requirements.txt` and configure SQLAlchemy with its async engine.
@@ -32,6 +34,8 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 - `GOOGLE_CALENDAR_ID` – ID of the calendar to read events from.
 - `G_EVENT_CAL_ID` – ID of the Google Calendar used for event syncs.
 - `G_SHIFT_CAL_ID` – ID of the Google Calendar used for shift syncs.
+- `CORS_ORIGINS` – (optional) comma separated list of allowed origins for
+  cross-origin requests. Defaults to `"*"`.
 
 ## Database migrations
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import os
 from app.database import Base, engine
 from app.routes import (
     users,
@@ -23,9 +24,15 @@ def on_startup() -> None:
     """Create database tables on startup."""
     Base.metadata.create_all(bind=engine)
 
+origins = os.getenv("CORS_ORIGINS", "*")
+if origins == "*":
+    allow_origins = ["*"]
+else:
+    allow_origins = [o.strip() for o in origins.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- allow configuring allowed CORS origins via the new `CORS_ORIGINS` environment variable
- document the variable and its usage in the README
- show example entry in `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686564c3abc48323874de6c991daa73a