### PR TITLE
Add nome field to User model and update tests

### DIFF
--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -7,14 +7,19 @@ import uuid
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
-def create_user(db: Session, email: str, password: str):
+def create_user(db: Session, email: str, password: str, nome: str):
     """Create and return a new user with a hashed password."""
     existing_user = db.query(User).filter(User.email == email).first()
     if existing_user:
         raise HTTPException(status_code=409, detail="Email already registered")
 
     hashed_password = pwd_context.hash(password)
-    db_user = User(id=str(uuid.uuid4()), email=email, hashed_password=hashed_password)
+    db_user = User(
+        id=str(uuid.uuid4()),
+        email=email,
+        nome=nome,
+        hashed_password=hashed_password,
+    )
     db.add(db_user)
     db.commit()
     db.refresh(db_user)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -5,7 +5,7 @@ class User(Base):
     __tablename__ = "users"
     id = Column(String, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
-    nome = Column(String, nullable=False, default="", server_default="")
+    nome = Column(String, nullable=False)
     hashed_password = Column(String, nullable=False)
     todos = relationship("ToDo", back_populates="user")
     events = relationship("Event", back_populates="user")

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.dependencies import get_db
-from app.schemas.user import UserCreate
+from app.schemas.user import UserCreate, UserLogin
 from app.crud import user
 from jose import jwt
 import os
@@ -16,7 +16,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
 router = APIRouter(tags=["Auth"])
 
 @router.post("/login")
-def login(form_data: UserCreate, db: Session = Depends(get_db)):
+def login(form_data: UserLogin, db: Session = Depends(get_db)):
     """Authenticate a user and issue a JWT access token.
 
     The provided credentials are validated against the stored user data.

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -17,4 +17,4 @@ def list_users_route(
 @router.post("/", response_model=UserResponse)
 def create_user_route(user_data: UserCreate, db: Session = Depends(get_db)):
     """Register a new user and return it."""
-    return user.create_user(db, user_data.email, user_data.password)
+    return user.create_user(db, user_data.email, user_data.password, user_data.nome)

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -2,6 +2,12 @@ from pydantic import BaseModel
 class UserCreate(BaseModel):
     email: str
     password: str
+    nome: str
+
+
+class UserLogin(BaseModel):
+    email: str
+    password: str
 class UserResponse(BaseModel):
     id: str
     email: str

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -12,7 +12,7 @@ client = TestClient(app)
 def test_login_success(setup_db):
     client.post(
         "/users/",
-        json={"email": "auth@example.com", "password": "secret"},
+        json={"email": "auth@example.com", "password": "secret", "nome": "Test"},
     )
     response = client.post(
         "/login", json={"email": "auth@example.com", "password": "secret"}
@@ -26,7 +26,7 @@ def test_login_success(setup_db):
 def test_login_invalid_credentials(setup_db):
     client.post(
         "/users/",
-        json={"email": "wrong@example.com", "password": "secret"},
+        json={"email": "wrong@example.com", "password": "secret", "nome": "Test"},
     )
     response = client.post(
         "/login", json={"email": "wrong@example.com", "password": "bad"}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -10,7 +10,9 @@ client = TestClient(app)
 
 
 def auth_user(email: str):
-    resp = client.post("/users/", json={"email": email, "password": "secret"})
+    resp = client.post(
+        "/users/", json={"email": email, "password": "secret", "nome": "Test"}
+    )
     user_id = resp.json()["id"]
     token = client.post("/login", json={"email": email, "password": "secret"}).json()[
         "access_token"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -9,7 +9,9 @@ client = TestClient(app)
 
 
 def auth_user(email: str):
-    resp = client.post("/users/", json={"email": email, "password": "secret"})
+    resp = client.post(
+        "/users/", json={"email": email, "password": "secret", "nome": "Test"}
+    )
     user_id = resp.json()["id"]
     token = client.post("/login", json={"email": email, "password": "secret"}).json()["access_token"]
     return {"Authorization": f"Bearer {token}"}, user_id

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -10,7 +10,9 @@ client = TestClient(app)
 
 
 def auth_user(email: str):
-    resp = client.post("/users/", json={"email": email, "password": "secret"})
+    resp = client.post(
+        "/users/", json={"email": email, "password": "secret", "nome": "Test"}
+    )
     user_id = resp.json()["id"]
     token = client.post(
         "/login", json={"email": email, "password": "secret"}

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -12,7 +12,9 @@ client = TestClient(app)
 
 
 def auth_user(email: str):
-    resp = client.post("/users/", json={"email": email, "password": "secret"})
+    resp = client.post(
+        "/users/", json={"email": email, "password": "secret", "nome": "Test"}
+    )
     user_id = resp.json()["id"]
     token = client.post(
         "/login",

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -9,21 +9,37 @@ from app.main import app
 client = TestClient(app)
 
 def test_create_user():
-    response = client.post("/users/", json={"email": "test@example.com", "password": "secret"})
+    response = client.post(
+        "/users/",
+        json={"email": "test@example.com", "password": "secret", "nome": "Test"},
+    )
     assert response.status_code == 200
     data = response.json()
     assert data["email"] == "test@example.com"
+    assert data["nome"] == "Test"
     assert "id" in data
 
 def test_duplicate_user():
-    client.post("/users/", json={"email": "dup@example.com", "password": "secret"})
-    response = client.post("/users/", json={"email": "dup@example.com", "password": "secret"})
+    client.post(
+        "/users/",
+        json={"email": "dup@example.com", "password": "secret", "nome": "Test"},
+    )
+    response = client.post(
+        "/users/",
+        json={"email": "dup@example.com", "password": "secret", "nome": "Test"},
+    )
     assert response.status_code == 409
 
 
 def test_list_users():
-    client.post("/users/", json={"email": "a@example.com", "password": "secret"})
-    client.post("/users/", json={"email": "b@example.com", "password": "secret"})
+    client.post(
+        "/users/",
+        json={"email": "a@example.com", "password": "secret", "nome": "Test"},
+    )
+    client.post(
+        "/users/",
+        json={"email": "b@example.com", "password": "secret", "nome": "Test"},
+    )
     response = client.get("/users/")
     assert response.status_code == 200
     data = response.json()


### PR DESCRIPTION
## Summary
- require nome for User model
- store nome when creating a user
- expose nome in schemas and routes
- accept email/password only for login using new UserLogin schema
- update user creation in tests to send nome

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686564bfd3088323a068f112bbaee71d