### PR TITLE
Fix shift event summary fallback and update tests

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -64,7 +64,7 @@ def sync_shift_event(turno):
 
     body = {
         "id": evt_id,
-        "summary": turno.user.email,
+        "summary": turno.user.nome or turno.user.email.split("@")[0],
         "description": turno.note or "",
         "start": {"dateTime": iso_dt(turno.giorno, start)},
         "end":   {"dateTime": iso_dt(turno.giorno, end)},

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -11,9 +11,9 @@ with patch("google.oauth2.service_account.Credentials.from_service_account_file"
 client = TestClient(app)
 
 
-def auth_user(email: str):
+def auth_user(email: str, nome: str = "Test"):
     resp = client.post(
-        "/users/", json={"email": email, "password": "secret", "nome": "Test"}
+        "/users/", json={"email": email, "password": "secret", "nome": nome}
     )
     user_id = resp.json()["id"]
     token = client.post(
@@ -89,7 +89,7 @@ def test_delete_turno(setup_db):
 
 
 def test_shift_event_summary_email(setup_db):
-    headers, user_id = auth_user("cal@example.com")
+    headers, user_id = auth_user("cal@example.com", nome="Calendar User")
 
     captured = {}
 
@@ -117,4 +117,4 @@ def test_shift_event_summary_email(setup_db):
             headers=headers,
         )
 
-    assert captured["body"]["summary"] == "cal@example.com"
+    assert captured["body"]["summary"] == "Calendar User"


### PR DESCRIPTION
## Summary
- use user's nome or email username for calendar shift events
- allow specifying nome in turni tests
- expect nome in calendar shift event test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686564e53e9c8323a441a7a0d972e455