### PR TITLE
Rename UserLogin to UserCredentials

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.dependencies import get_db
-from app.schemas.user import UserCreate, UserLogin
+from app.schemas.user import UserCreate, UserCredentials
 from app.crud import user
 from jose import jwt
 import os
@@ -16,7 +16,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
 router = APIRouter(tags=["Auth"])
 
 @router.post("/login")
-def login(form_data: UserLogin, db: Session = Depends(get_db)):
+def login(form_data: UserCredentials, db: Session = Depends(get_db)):
     """Authenticate a user and issue a JWT access token.
 
     The provided credentials are validated against the stored user data.

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -5,7 +5,7 @@ class UserCreate(BaseModel):
     nome: str
 
 
-class UserLogin(BaseModel):
+class UserCredentials(BaseModel):
     email: str
     password: str
 class UserResponse(BaseModel):


### PR DESCRIPTION
## Summary
- rename `UserLogin` schema to `UserCredentials`
- update auth route import and parameter type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865742176ec8323ab7218efb54618ff