### PR TITLE
Add optional DB session to parse_excel

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -25,7 +25,7 @@ async def import_xlsx(
         tmp_path = tmp.name
 
     # 2 – parse Excel -> TurnoIn payloads
-    rows = parse_excel(tmp_path, db)
+    rows = parse_excel(tmp_path, db=db)
 
     # 3 – store/update each shift (DB + Google Calendar)
     for payload in rows:

--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -7,23 +7,35 @@ from sqlalchemy.orm import Session
 from app.models.user import User
 
 
-def parse_excel(path: str, db: Session) -> List[Dict[str, Any]]:
+def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
     """Parse an Excel file into TurnoIn-compatible payloads.
 
-    Colonne obbligatorie / Required columns: ``Data``, ``Agente``,
-    ``Inizio1`` e ``Fine1``. Colonne facoltative / Optional: ``Inizio2``,
-    ``Fine2``, ``Inizio3``, ``Fine3``, ``Tipo`` e ``Note``.
+    The function accepts either a ``User ID`` column directly or an ``Agente``
+    column. When ``Agente`` is used, a SQLAlchemy ``Session`` must be provided
+    to resolve user names.
+
+    Colonne obbligatorie / Required columns: ``Data``, ``Inizio1`` and
+    ``Fine1``. Provide either ``User ID`` or ``Agente`` to associate the shift.
+    Optional columns: ``Inizio2``, ``Fine2``, ``Inizio3``, ``Fine3``, ``Tipo`` e
+    ``Note``.
 
     :return: a list of dictionaries ready for the TurnoIn API.
     """
     df = pd.read_excel(path)  # requires openpyxl
     rows: list[dict[str, Any]] = []
     for _, row in df.iterrows():
-        user = db.query(User).filter(User.nome == row["Agente"]).first()
-        if not user:
-            raise ValueError(f"Unknown user: {row['Agente']}")
+        if db is not None and "Agente" in df.columns:
+            user = db.query(User).filter(User.nome == row["Agente"]).first()
+            if not user:
+                raise ValueError(f"Unknown user: {row['Agente']}")
+            user_id = str(user.id)
+        elif "User ID" in df.columns:
+            user_id = str(row["User ID"])
+        else:
+            raise ValueError("User information missing: provide 'User ID' column or a DB session with 'Agente'.")
+
         payload: dict[str, Any] = {
-            "user_id": str(user.id),
+            "user_id": user_id,
             "giorno": row["Data"].date() if hasattr(row["Data"], "date") else row["Data"],
             "slot1": {"inizio": row["Inizio1"], "fine": row["Fine1"]},
             "tipo": row.get("Tipo", "NORMALE"),


### PR DESCRIPTION
## Summary
- make DB session optional in `parse_excel`
- pass named DB argument from import route
- expand docstring for `parse_excel`
- test new behaviour with DB session

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865762517bc8323bcd7e446e93a2e97