### PR TITLE
Handle parse errors when importing shifts

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, UploadFile, Depends, BackgroundTasks
+from fastapi import APIRouter, UploadFile, Depends, BackgroundTasks, HTTPException
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 import tempfile
@@ -25,7 +25,11 @@ async def import_xlsx(
         tmp_path = tmp.name
 
     # 2 – parse Excel -> TurnoIn payloads
-    rows = parse_excel(tmp_path, db=db)
+    try:
+        rows = parse_excel(tmp_path, db=db)
+    except HTTPException:
+        os.remove(tmp_path)
+        raise
 
     # 3 – store/update each shift (DB + Google Calendar)
     for payload in rows:


### PR DESCRIPTION
## Summary
- clean up temporary XLSX file when `parse_excel` raises an `HTTPException`
- test that the XLSX file is removed and a 400 response is returned

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686578c680f08323851c8715cc061ff3