### PR TITLE
Add missing column check when parsing Excel

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -4,6 +4,7 @@ import tempfile
 import os
 from typing import Any, Dict, List, Tuple
 from sqlalchemy.orm import Session
+from fastapi import HTTPException
 
 from app.models.user import User
 
@@ -34,6 +35,12 @@ def parse_excel(path: str, db: Session) -> List[Dict[str, Any]]:
     """
 
     df = pd.read_excel(path)  # requires openpyxl
+
+    required = {"Data", "User ID", "Inizio1", "Fine1"}
+    missing = required - set(df.columns)
+    if missing:
+        raise HTTPException(status_code=400, detail=f"Missing columns: {missing}")
+
     rows: list[dict[str, Any]] = []
 
     for _, row in df.iterrows():


### PR DESCRIPTION
## Summary
- validate required columns in `parse_excel`
- import `HTTPException`

## Testing
- `pytest -q tests/test_excel_import.py::test_parse_excel` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686578c4444083238223fac3b5aac9d2