### PR TITLE
Update Excel import parsing

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -22,31 +22,34 @@ def get_user_id(db: Session, agente: str) -> str:
     return str(user.id)
 
 
-def parse_excel(path: str, db: Session) -> List[Dict[str, Any]]:
+def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
     """Parse an Excel file exported from Google Sheets.
 
     The sheet must contain the columns ``Agente``, ``Data`` and ``Tipo`` in
     addition to ``Inizio1``/``Fine1``. If present, ``Inizio2``/``Fine2`` will be
     mapped to ``slot2`` while ``Straordinario inizio``/``Straordinario fine`` are
     mapped to ``slot3``. ``Agente`` is resolved to a ``User.id`` using the
-    provided ``Session``.
+    provided ``Session`` when available, otherwise its value is used as-is.
 
     :return: a list of dictionaries ready for the TurnoIn API.
     """
 
     df = pd.read_excel(path)  # requires openpyxl
 
-    required = {"Data", "User ID", "Inizio1", "Fine1"}
+    required = {"Agente", "Data", "Tipo", "Inizio1", "Fine1"}
     missing = required - set(df.columns)
     if missing:
         raise HTTPException(status_code=400, detail=f"Missing columns: {missing}")
 
-    rows: list[dict[str, Any]] = []
+    rows: List[Dict[str, Any]] = []
 
     for _, row in df.iterrows():
-        user_id = get_user_id(db, row["Agente"])
+        agente_value = row["Agente"]
+        user_id = (
+            get_user_id(db, agente_value) if db is not None else str(agente_value)
+        )
 
-        payload: dict[str, Any] = {
+        payload: Dict[str, Any] = {
             "user_id": user_id,
             "giorno": row["Data"].date() if hasattr(row["Data"], "date") else row["Data"],
             "slot1": {"inizio": row["Inizio1"], "fine": row["Fine1"]},
@@ -54,7 +57,11 @@ def parse_excel(path: str, db: Session) -> List[Dict[str, Any]]:
             "note": "",
         }
 
-        if "Inizio2" in df.columns and not pd.isna(row.get("Inizio2")) and not pd.isna(row.get("Fine2")):
+        if (
+            "Inizio2" in df.columns
+            and not pd.isna(row.get("Inizio2"))
+            and not pd.isna(row.get("Fine2"))
+        ):
             payload["slot2"] = {"inizio": row["Inizio2"], "fine": row["Fine2"]}
 
         if (

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -10,24 +10,22 @@ from app.services.excel_import import parse_excel, df_to_pdf
 def test_parse_excel(tmp_path):
     df = pd.DataFrame([
         {
-            "User ID": 1,
+            "Agente": 1,
             "Data": "2023-01-01",
             "Inizio1": "08:00:00",
             "Fine1": "12:00:00",
             "Tipo": "NORMALE",
-            "Note": "n1",
         },
         {
-            "User ID": "2",
+            "Agente": "2",
             "Data": "2023-01-02",
             "Inizio1": "09:00:00",
             "Fine1": "13:00:00",
             "Inizio2": "14:00:00",
             "Fine2": "18:00:00",
-            "Inizio3": "19:00:00",
-            "Fine3": "21:00:00",
+            "Straordinario inizio": "19:00:00",
+            "Straordinario fine": "21:00:00",
             "Tipo": "EXTRA",
-            "Note": "n2",
         },
     ])
     xls = tmp_path / "sample.xlsx"
@@ -41,7 +39,7 @@ def test_parse_excel(tmp_path):
             "giorno": "2023-01-01",
             "slot1": {"inizio": "08:00:00", "fine": "12:00:00"},
             "tipo": "NORMALE",
-            "note": "n1",
+            "note": "",
         },
         {
             "user_id": "2",
@@ -50,7 +48,7 @@ def test_parse_excel(tmp_path):
             "slot2": {"inizio": "14:00:00", "fine": "18:00:00"},
             "slot3": {"inizio": "19:00:00", "fine": "21:00:00"},
             "tipo": "EXTRA",
-            "note": "n2",
+            "note": "",
         },
     ]
 
@@ -71,6 +69,7 @@ def test_parse_excel_with_db(tmp_path):
             "Data": "2023-01-03",
             "Inizio1": "07:00:00",
             "Fine1": "11:00:00",
+            "Tipo": "NORMALE",
         }
     ])
     xls = tmp_path / "agent.xlsx"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -29,6 +29,7 @@ def test_import_xlsx_creates_turni_and_returns_pdf(setup_db, tmp_path):
             "Data": "2023-01-01",
             "Inizio1": "08:00:00",
             "Fine1": "12:00:00",
+            "Tipo": "NORMALE",
         }
     ])
     xlsx_path = tmp_path / "shift.xlsx"


### PR DESCRIPTION
## Summary
- update Excel parser to use `Agente` column and map optional columns
- adjust tests for new parser expectations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68657a7bea94832380293d9076413580