### PR TITLE
Fix Excel import required columns

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -36,7 +36,7 @@ def parse_excel(path: str, db: Session) -> List[Dict[str, Any]]:
 
     df = pd.read_excel(path)  # requires openpyxl
 
-    required = {"Data", "User ID", "Inizio1", "Fine1"}
+    required = {"Agente", "Data", "Inizio1", "Fine1"}
     missing = required - set(df.columns)
     if missing:
         raise HTTPException(status_code=400, detail=f"Missing columns: {missing}")


### PR DESCRIPTION
## Summary
- enforce "Agente" column in Excel import parser
- update parsing tests to use agent names via DB lookup

## Testing
- `pytest -k excel_import -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68657a69b9f88323b15425908f4ffbcd