### PR TITLE
Update route call to parse_excel

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -26,7 +26,7 @@ async def import_xlsx(
 
     # 2 – parse Excel -> TurnoIn payloads
     try:
-        rows = parse_excel(tmp_path, db=db)
+        rows = parse_excel(tmp_path, db)
     except HTTPException:
         os.remove(tmp_path)
         raise

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -36,7 +36,7 @@ def test_parse_excel(tmp_path):
     xls = tmp_path / "sample.xlsx"
     df.to_excel(xls, index=False)
 
-    rows = parse_excel(str(xls))
+    rows = parse_excel(str(xls), None)
 
     assert rows == [
         {
@@ -79,7 +79,7 @@ def test_parse_excel_with_db(tmp_path):
     xls = tmp_path / "agent.xlsx"
     df.to_excel(xls, index=False)
 
-    rows = parse_excel(str(xls), db=db)
+    rows = parse_excel(str(xls), db)
 
     assert rows == [
         {
@@ -112,7 +112,7 @@ def test_parse_excel_missing_column(tmp_path):
     df.to_excel(xls, index=False)
 
     with pytest.raises(HTTPException) as exc:
-        parse_excel(str(xls), db=db)
+        parse_excel(str(xls), db)
 
     assert exc.value.status_code == 400
     assert "Missing columns" in exc.value.detail


### PR DESCRIPTION
## Summary
- adjust `/import/xlsx` endpoint to call `parse_excel(tmp_path, db)`
- adapt tests for new `parse_excel()` argument order

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68657b9f95d88323badda51ca0d52a77