### PR TITLE
Fix os import not used

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import pdfkit
 import tempfile
-import os
 from typing import Any, Dict, List, Tuple
 from sqlalchemy.orm import Session
 from fastapi import HTTPException


### PR DESCRIPTION
## Summary
- remove unused os import from excel_import.py

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68657ca0e8a08323bc1f76a76825b286