### PR TITLE
Handle unknown agents in Excel import

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -56,7 +56,10 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
         else:
             if not db:
                 raise HTTPException(status_code=400, detail="Database session required to resolve 'Agente'")
-            user_id = get_user_id(db, row["Agente"])
+            try:
+                user_id = get_user_id(db, row["Agente"])
+            except ValueError as err:
+                raise HTTPException(status_code=400, detail=str(err))
 
         payload: dict[str, Any] = {
             "user_id": user_id,

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -127,3 +127,26 @@ def test_import_excel_alias_returns_pdf(tmp_path):
 
     assert res.status_code == 200
     assert res.headers["content-type"] == "application/pdf"
+
+
+def test_import_xlsx_unknown_agent_returns_400(tmp_path):
+    """Uploading a sheet with an unknown Agente should return a 400 response."""
+    df = pd.DataFrame([
+        {
+            "Agente": "Unknown Agent",
+            "Data": "2023-01-01",
+            "Inizio1": "08:00:00",
+            "Fine1": "12:00:00",
+        }
+    ])
+    xlsx_path = tmp_path / "unknown.xlsx"
+    df.to_excel(xlsx_path, index=False)
+
+    with open(xlsx_path, "rb") as fh:
+        res = client.post(
+            "/import/xlsx",
+            files={"file": ("unknown.xlsx", fh, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+        )
+
+    assert res.status_code == 400
+    assert "Unknown user" in res.json()["detail"]


### PR DESCRIPTION
## Summary
- raise HTTP 400 when `get_user_id` fails in `parse_excel`
- add a regression test for uploading an Excel sheet with an unknown agent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pdfkit')*

------
https://chatgpt.com/codex/tasks/task_e_6866682f94648323877d1645e042b6be