### PR TITLE
Add CI test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ pytest
 The test suite uses a temporary SQLite database, so no additional
 configuration is required.
 
+## Continuous Integration
+
+All pushes and pull requests trigger a GitHub Actions workflow. It sets up
+Python 3.11, installs the dependencies from `requirements.txt` and runs
+`pytest`. The job fails if any tests fail.
+
 ## Deployment
 
 When deploying on platforms like Render or Railway, ensure `wkhtmltopdf` is


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run pytest with Python 3.11
- document the new CI workflow in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866683749e0832384d66f705deca23a