### PR TITLE
Separate dev requirements

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -36,7 +36,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y wkhtmltopdf
 
     - name: Install dependencies
-      run: pip install -r requirements.txt
+      run: pip install -r requirements.txt -r requirements-dev.txt
 
     # - name: Run migrations
     #   run: alembic upgrade head

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains a FastAPI backend used by Segretaria Digitale.
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
-   pip install -r requirements.txt
+   pip install -r requirements.txt -r requirements-dev.txt
    ```
 3. Install [wkhtmltopdf](https://wkhtmltopdf.org/downloads.html) at the system
    level (e.g. `apt-get update && apt-get install -y wkhtmltopdf`). This is
@@ -70,7 +70,7 @@ The API will be available at `http://localhost:8000/` by default.
 ## Running tests
 
 Tests are located in the `tests/` directory. After installing the
-dependencies simply run:
+dependencies from both `requirements.txt` and `requirements-dev.txt`, simply run:
 
 ```bash
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+flake8
+black

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ passlib[bcrypt]
 bcrypt<4.0
 python-jose[cryptography]
 psycopg2-binary
-pytest
 httpx
 alembic
 python-multipart


### PR DESCRIPTION
## Summary
- add requirements-dev.txt for development tools
- remove pytest from requirements.txt
- document installing dev dependencies in README
- install dev dependencies in GitHub Actions workflow

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686668387b6c83239ac9b2108e105f4f