### PR TITLE
Add authentication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000
 
 The API will be available at `http://localhost:8000/` by default.
 
+## Authentication
+
+Obtain a JWT access token using `POST /login`. The endpoint only accepts a
+`POST` request; `GET` requests are not supported.
+
+Example:
+
+```bash
+curl -X POST http://localhost:8000/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "password": "yourpassword"}'
+```
+
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- document how to retrieve JWT token via POST /login

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68666f8adc408323b563bbb41c30f85d