### PR TITLE
Add Docker ignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Version control
+.git
+
+# Python artifacts
+__pycache__/
+*.pyc
+
+# Virtual environments
+.venv/
+venv/
+
+# Testing and development caches
+.pytest_cache/
+.mypy_cache/
+
+# Distribution / build artifacts
+*.egg-info/
+dist/
+build/
+
+# Logs and environment files
+*.log
+.env
+
+# Tests
+tests/
+
+# Misc
+Stemma 2k25 definitivo.png


### PR DESCRIPTION
## Summary
- add a `.dockerignore` to exclude development and testing files from Docker build contexts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866709b61b083238bf466bab388e5ec