### PR TITLE
Fix parameter order in import endpoints

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -15,8 +15,8 @@ router = APIRouter(prefix="/import", tags=["Import"])
 @router.post("/xlsx")
 async def import_xlsx(
     file: UploadFile,
-    db: Session = Depends(get_db),
     background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
 ):
     """Import Excel shifts, sync them and return a PDF summary."""
     # 1 – save temp file
@@ -46,8 +46,8 @@ async def import_xlsx(
 @router.post("/excel", include_in_schema=False)
 async def import_excel(
     file: UploadFile,
-    db: Session = Depends(get_db),
     background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
 ):
     """Alias for :func:`import_xlsx`"""
-    return await import_xlsx(file=file, db=db, background_tasks=background_tasks)
+    return await import_xlsx(file=file, background_tasks=background_tasks, db=db)


### PR DESCRIPTION
## Summary
- fix the order of parameters in `import_xlsx` and `import_excel`
- update alias call accordingly
- run `py_compile` to ensure the module compiles

## Testing
- `python -m py_compile app/routes/imports.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686675a3ee5c8323952db555ba5ea861