### PR TITLE
Handle wkhtmltopdf missing

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -106,5 +106,13 @@ def df_to_pdf(rows: List[Dict[str, Any]]) -> Tuple[str, str]:
         df.to_html(tmp_html.name, index=False)
         html_path = tmp_html.name
     pdf_path = html_path.replace(".html", ".pdf")
-    pdfkit.from_file(html_path, pdf_path)  # requires wkhtmltopdf installed
+    try:
+        pdfkit.from_file(html_path, pdf_path)  # requires wkhtmltopdf installed
+    except OSError as err:
+        if "wkhtmltopdf" in str(err):
+            raise HTTPException(
+                status_code=500,
+                detail="wkhtmltopdf not installed",
+            )
+        raise
     return pdf_path, html_path


### PR DESCRIPTION
## Summary
- raise a 500 HTTPException when `pdfkit` can't find `wkhtmltopdf`
- test pdf export error handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686676fc90f883239ae7f280be3a4846