### PR TITLE
Include shifts in user responses

### DIFF
--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from fastapi import HTTPException
 from app.models.user import User
 from passlib.context import CryptContext
@@ -37,5 +37,10 @@ def verify_password(plain_password, hashed_password):
 
 
 def list_users(db: Session):
-    """Restituisce tutti gli utenti ordinati per nome."""
-    return db.query(User).order_by(User.nome.asc()).all()
+    """Restituisce tutti gli utenti ordinati per nome con i turni caricati."""
+    return (
+        db.query(User)
+        .options(joinedload(User.turni))
+        .order_by(User.nome.asc())
+        .all()
+    )

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from app.schemas.turno import TurnoOut
 class UserCreate(BaseModel):
     email: str
     password: str
@@ -12,5 +13,6 @@ class UserResponse(BaseModel):
     id: str
     email: str
     nome: str
+    turni: list[TurnoOut] = []
     class Config:
         orm_mode = True

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 # Set test database before importing the app
@@ -7,6 +8,15 @@ os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 from app.main import app
 
 client = TestClient(app)
+
+def auth_user(email: str, nome: str = "Test"):
+    resp = client.post(
+        "/users/",
+        json={"email": email, "password": "secret", "nome": nome},
+    )
+    user_id = resp.json()["id"]
+    token = client.post("/login", json={"email": email, "password": "secret"}).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}, user_id
 
 def test_create_user():
     response = client.post(
@@ -18,6 +28,7 @@ def test_create_user():
     assert data["email"] == "test@example.com"
     assert data["nome"] == "Test"
     assert "id" in data
+    assert data["turni"] == []
 
 def test_duplicate_user():
     client.post(
@@ -44,4 +55,27 @@ def test_list_users():
     assert response.status_code == 200
     data = response.json()
     assert [u["nome"] for u in data] == ["Alpha", "Beta"]
+
+
+def test_user_turni_listed_after_creation(setup_db):
+    with patch("app.services.gcal.sync_shift_event"), patch("app.services.gcal.delete_shift_event"):
+        headers, user_id = auth_user("shift@example.com")
+
+        shift = {
+            "user_id": user_id,
+            "giorno": "2023-01-01",
+            "slot1": {"inizio": "08:00:00", "fine": "12:00:00"},
+            "slot2": None,
+            "slot3": None,
+            "tipo": "NORMALE",
+            "note": "",
+        }
+        res = client.post("/orari/", json=shift, headers=headers)
+        assert res.status_code == 200
+
+        res = client.get("/users/")
+        assert res.status_code == 200
+        users = res.json()
+        found = next(u for u in users if u["id"] == user_id)
+        assert len(found["turni"]) == 1
 


### PR DESCRIPTION
## Summary
- add `turni` field in user schema referencing `TurnoOut`
- eager load `turni` relation when listing users
- check for shifts in user-related tests

## Testing
- `pytest -q tests/test_users.py::test_create_user -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686676f977088323b7a56efe6a03a0cb