### PR TITLE
Add weekly turni PDF endpoint

### DIFF
--- a/app/crud/turno.py
+++ b/app/crud/turno.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 from fastapi import HTTPException, status
+from datetime import date
 import logging
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,17 @@ def list_all(db: Session) -> list[Turno]:
     """Return all ``Turno`` records in the database ordered by date."""
     return (
         db.query(Turno)
+        .order_by(Turno.giorno.asc())
+        .all()
+    )
+
+
+# ------------------------------------------------------------------------------
+def list_between(db: Session, start: date, end: date) -> list[Turno]:
+    """Return ``Turno`` records between ``start`` and ``end`` dates."""
+    return (
+        db.query(Turno)
+        .filter(Turno.giorno >= start, Turno.giorno <= end)
         .order_by(Turno.giorno.asc())
         .all()
     )

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -1,0 +1,76 @@
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+# Patch Google API clients before importing the app
+with patch("google.oauth2.service_account.Credentials.from_service_account_file", return_value=MagicMock()):
+    with patch("googleapiclient.discovery.build", return_value=MagicMock()):
+        os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+        from app.main import app
+
+client = TestClient(app)
+
+
+def auth_user(email: str, nome: str = "Test"):
+    resp = client.post("/users/", json={"email": email, "password": "secret", "nome": nome})
+    user_id = resp.json()["id"]
+    token = client.post("/login", json={"email": email, "password": "secret"}).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}, user_id
+
+
+def test_week_pdf_filters_turni(setup_db, tmp_path):
+    headers, user_id = auth_user("week@example.com")
+
+    shift1 = {
+        "user_id": user_id,
+        "giorno": "2023-01-02",
+        "slot1": {"inizio": "08:00:00", "fine": "12:00:00"},
+        "slot2": None,
+        "slot3": None,
+        "tipo": "NORMALE",
+        "note": "",
+    }
+    shift2 = {
+        "user_id": user_id,
+        "giorno": "2023-01-08",
+        "slot1": {"inizio": "09:00:00", "fine": "13:00:00"},
+        "slot2": None,
+        "slot3": None,
+        "tipo": "NORMALE",
+        "note": "",
+    }
+    shift3 = {
+        "user_id": user_id,
+        "giorno": "2023-01-09",
+        "slot1": {"inizio": "10:00:00", "fine": "14:00:00"},
+        "slot2": None,
+        "slot3": None,
+        "tipo": "NORMALE",
+        "note": "",
+    }
+
+    client.post("/orari/", json=shift1, headers=headers)
+    client.post("/orari/", json=shift2, headers=headers)
+    client.post("/orari/", json=shift3, headers=headers)
+
+    captured = {}
+    real_df_to_pdf = __import__("app.services.excel_import", fromlist=["df_to_pdf"]).df_to_pdf
+
+    def fake_from_file(html_path, pdf_path):
+        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
+        return True
+
+    def capture_df_to_pdf(rows):
+        captured["rows"] = rows
+        return real_df_to_pdf(rows)
+
+    with patch("app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file):
+        with patch("app.routes.orari.df_to_pdf", side_effect=capture_df_to_pdf):
+            res = client.get("/orari/pdf?week=2023-W01", headers=headers)
+
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "application/pdf"
+    assert len(captured["rows"]) == 2
+    days = {r["giorno"] for r in captured["rows"]}
+    assert days == {"2023-01-02", "2023-01-08"}


### PR DESCRIPTION
## Summary
- support querying shifts by week via `GET /orari/pdf`
- add helper `list_between` in CRUD layer
- unit test verifying weekly PDF generation and filtering

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68667b2878a88323951f206a15b15296