### PR TITLE
Validate user IDs in Excel import

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -53,6 +53,12 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
     for _, row in df.iterrows():
         if "User ID" in df.columns:
             user_id = str(row["User ID"])
+            if db is not None:
+                exists = db.query(User.id).filter(User.id == user_id).first()
+                if not exists:
+                    raise HTTPException(
+                        status_code=400, detail=f"Unknown user ID: {user_id}"
+                    )
         else:
             if not db:
                 raise HTTPException(status_code=400, detail="Database session required to resolve 'Agente'")

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -169,6 +169,32 @@ def test_parse_excel_agente_without_db(tmp_path):
     assert "Database session required" in exc.value.detail
 
 
+def test_parse_excel_unknown_user_id(tmp_path):
+    """An HTTPException is raised for an unknown User ID when a DB session is provided."""
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+
+    df = pd.DataFrame([
+        {
+            "User ID": "missing",
+            "Data": "2023-03-01",
+            "Inizio1": "08:00:00",
+            "Fine1": "12:00:00",
+        }
+    ])
+    xls = tmp_path / "unknown_id.xlsx"
+    df.to_excel(xls, index=False)
+
+    with pytest.raises(HTTPException) as exc:
+        parse_excel(str(xls), db)
+
+    assert exc.value.status_code == 400
+    assert "Unknown user ID" in exc.value.detail
+
+    db.close()
+
+
 def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     rows = [
         {


### PR DESCRIPTION
## Summary
- validate `User ID` references when a DB session is supplied
- test `parse_excel` with an invalid user id

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68667bd929208323ad21c1c2ea9df466