### PR TITLE
Validate user ID when parsing Excel

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -58,6 +58,13 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
 
         if user_col == "User ID":
             user_id = str(value)
+            if db:
+                user = db.query(User).filter(User.id == user_id).first()
+                if not user:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Unknown user ID: {user_id}",
+                    )
         else:
             if not db:
                 raise HTTPException(status_code=400, detail="Database session required to resolve 'Agente'")

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -214,6 +214,32 @@ def test_parse_excel_empty_agente(tmp_path):
 
     db.close()
 
+
+def test_parse_excel_unknown_user_id(tmp_path):
+    """An invalid User ID should raise an HTTPException when a DB session is supplied."""
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+
+    df = pd.DataFrame([
+        {
+            "User ID": "missing",
+            "Data": "2023-04-01",
+            "Inizio1": "08:00:00",
+            "Fine1": "12:00:00",
+        }
+    ])
+    xls = tmp_path / "unknown_id.xlsx"
+    df.to_excel(xls, index=False)
+
+    with pytest.raises(HTTPException) as exc:
+        parse_excel(str(xls), db)
+
+    assert exc.value.status_code == 400
+    assert "Unknown user ID" in exc.value.detail
+
+    db.close()
+
 def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     rows = [
         {


### PR DESCRIPTION
## Summary
- check the database when a User ID column is provided
- raise a 400 error for unknown user IDs
- cover the new behaviour in tests

## Testing
- `pytest tests/test_excel_import.py::test_parse_excel_unknown_user_id -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68667ca41f908323acc64c962774349c