### PR TITLE
Centralize google api patches for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 import os
-import pytest
 import shutil
 import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 # Ensure DATABASE_URL is set for tests
 os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
@@ -32,3 +34,14 @@ def setup_upload_dir(tmp_path):
 
     yield
     shutil.rmtree(str(upload_dir), ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def patch_google_clients():
+    """Mock Google API clients so tests run without network access."""
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_file",
+        return_value=MagicMock(),
+    ):
+        with patch("googleapiclient.discovery.build", return_value=MagicMock()):
+            yield

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,9 +1,4 @@
-import os
 from fastapi.testclient import TestClient
-
-# Use test database for these tests
-os.environ["DATABASE_URL"] = "sqlite:///./test.db"
-
 from app.main import app
 
 client = TestClient(app)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,13 +1,9 @@
-import os
 from datetime import datetime, timedelta
 from fastapi.testclient import TestClient
-
-os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from app.main import app
 
 client = TestClient(app)
-
 
 def auth_user(email: str):
     resp = client.post(

--- a/tests/test_determinazioni.py
+++ b/tests/test_determinazioni.py
@@ -1,7 +1,5 @@
-import os
 from fastapi.testclient import TestClient
 
-os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from app.main import app
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,7 +1,4 @@
-import os
 from fastapi.testclient import TestClient
-
-os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from app.main import app
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,15 +1,11 @@
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from pathlib import Path
 import pandas as pd
 from fastapi.testclient import TestClient
 from fastapi import HTTPException
 
-# Patch Google API clients before importing the app
-with patch("google.oauth2.service_account.Credentials.from_service_account_file", return_value=MagicMock()):
-    with patch("googleapiclient.discovery.build", return_value=MagicMock()):
-        os.environ["DATABASE_URL"] = "sqlite:///./test.db"
-        from app.main import app
+from app.main import app
 
 client = TestClient(app)
 

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -1,13 +1,8 @@
-import os
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from fastapi.testclient import TestClient
 
-# Patch Google API clients before importing the app
-with patch("google.oauth2.service_account.Credentials.from_service_account_file", return_value=MagicMock()):
-    with patch("googleapiclient.discovery.build", return_value=MagicMock()):
-        os.environ["DATABASE_URL"] = "sqlite:///./test.db"
-        from app.main import app
+from app.main import app
 
 client = TestClient(app)
 

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -1,12 +1,9 @@
-import os
 from fastapi.testclient import TestClient
 
-os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from app.main import app
 
 client = TestClient(app)
-
 
 def test_upload_pdf_and_list(setup_db, tmp_path):
     pdf_path = tmp_path / "sample.pdf"

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,8 +1,4 @@
-import os
 from fastapi.testclient import TestClient
-
-# Use same test database
-os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from app.main import app
 

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -1,12 +1,7 @@
-import os
 from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
 
-# Patch Google API clients before importing the app
-with patch("google.oauth2.service_account.Credentials.from_service_account_file", return_value=MagicMock()):
-    with patch("googleapiclient.discovery.build", return_value=MagicMock()):
-        os.environ["DATABASE_URL"] = "sqlite:///./test.db"
-        from app.main import app
+from app.main import app
 
 client = TestClient(app)
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,9 +1,5 @@
-import os
 from unittest.mock import patch
 from fastapi.testclient import TestClient
-
-# Set test database before importing the app
-os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from app.main import app
 


### PR DESCRIPTION
## Summary
- add `patch_google_clients` fixture that mocks Google API clients
- remove redundant patching code and env var settings from tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686688bb3c4c8323818b708aca542a9f