### PR TITLE
Add user lookup endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ The response is a chronologically ordered list where each item contains a
 Creating an event via `POST /events/` now returns HTTP status code `201` along
 with the created event.
 
+## Users endpoint
+
+Look up a user by email:
+
+```bash
+GET /users/by-email?email=<address>
+```
+
+Returns the matching user or `404` if none exists.
+
 ## Excel import endpoint
 
 The `/import/xlsx` route accepts an Excel file containing shift data. It parses

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.dependencies import get_db
 from app.schemas.user import UserCreate, UserResponse
@@ -18,3 +18,13 @@ def list_users_route(
 def create_user_route(user_data: UserCreate, db: Session = Depends(get_db)):
     """Register a new user and return it."""
     return user.create_user(db, user_data.email, user_data.password, user_data.nome)
+
+# ───── nuovo endpoint GET /users/by-email ─────
+@router.get("/by-email", response_model=UserResponse)
+def get_user_by_email_route(email: str, db: Session = Depends(get_db)):
+    """Return a user by email or raise 404 if not found."""
+    result = user.get_user_by_email(db, email)
+    if not result:
+        raise HTTPException(status_code=404, detail="User not found")
+    return result
+# ───────────────────────────────────────────────

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -75,3 +75,22 @@ def test_user_turni_listed_after_creation(setup_db):
         found = next(u for u in users if u["id"] == user_id)
         assert len(found["turni"]) == 1
 
+
+def test_get_user_by_email_success():
+    resp = client.post(
+        "/users/",
+        json={"email": "lookup@example.com", "password": "secret", "nome": "Lookup"},
+    )
+    user_id = resp.json()["id"]
+
+    response = client.get("/users/by-email", params={"email": "lookup@example.com"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == user_id
+    assert data["email"] == "lookup@example.com"
+
+
+def test_get_user_by_email_not_found():
+    response = client.get("/users/by-email", params={"email": "missing@example.com"})
+    assert response.status_code == 404
+


### PR DESCRIPTION
## Summary
- add `/users/by-email` route for fetching users by email
- test retrieving a user by email
- document the route in README

## Testing
- `pytest tests/test_users.py::test_get_user_by_email_success -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866aff748808323a81e3f2dca21de6b