### PR TITLE
Add health check route

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ scheduled in the specified ISO week. The `week` parameter identifies the week
 using the `YYYY-Www` format (for example, `2023-W42`). Authentication is
 required.
 
+## Health endpoint
+
+Check that required configuration and the database connection are working:
+
+```bash
+GET /health
+```
+
+A successful call returns status `200` with `{ "status": "ok" }`.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from app.routes import (
     determinazioni,
     pdfs,
     dashboard,
+    health,
 )
 from app.routes.orari import router as orari_router
 from app.routes import imports
@@ -41,6 +42,7 @@ app.include_router(todo.router)
 app.include_router(determinazioni.router)
 app.include_router(pdfs.router)
 app.include_router(dashboard.router)
+app.include_router(health.router)
 app.include_router(orari_router)
 app.include_router(imports.router)
 

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+import os
+
+from app.dependencies import get_db
+
+router = APIRouter(tags=["Health"])
+
+
+@router.get("/health")
+def health_check(db: Session = Depends(get_db)):
+    """Check environment and database connectivity."""
+    if not os.getenv("DATABASE_URL"):
+        raise HTTPException(status_code=500, detail="DATABASE_URL not configured")
+    if not os.getenv("SECRET_KEY"):
+        raise HTTPException(status_code=500, detail="SECRET_KEY not configured")
+    db.execute(text("SELECT 1"))
+    return {"status": "ok"}

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health_ok(setup_db):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- implement `/health` route verifying env vars and DB
- expose the new router in main app
- document health check endpoint in README
- test `/health` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866c506b84c83239ba7fffb1a69594f