### PR TITLE
Map ORM turno columns via alias fields

### DIFF
--- a/app/models/turno.py
+++ b/app/models/turno.py
@@ -21,3 +21,23 @@ class Turno(Base):
     note = Column(String, nullable=True)
 
     user = relationship("User", back_populates="turni")
+
+    # Properties used by Pydantic alias mapping ------------------------------
+    @property
+    def inizio_1_fine_1(self) -> dict[str, Time]:
+        """Return slot1 as a dictionary for Pydantic alias mapping."""
+        return {"inizio": self.inizio_1, "fine": self.fine_1}
+
+    @property
+    def inizio_2_fine_2(self) -> dict[str, Time] | None:
+        """Return slot2 or ``None`` if not fully specified."""
+        if self.inizio_2 and self.fine_2:
+            return {"inizio": self.inizio_2, "fine": self.fine_2}
+        return None
+
+    @property
+    def inizio_3_fine_3(self) -> dict[str, Time] | None:
+        """Return slot3 or ``None`` if not fully specified."""
+        if self.inizio_3 and self.fine_3:
+            return {"inizio": self.inizio_3, "fine": self.fine_3}
+        return None

--- a/app/schemas/turno.py
+++ b/app/schemas/turno.py
@@ -1,5 +1,5 @@
 from datetime import date, time
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional
 
 class Slot(BaseModel):
@@ -8,11 +8,14 @@ class Slot(BaseModel):
 
 class TurnoBase(BaseModel):
     giorno: date
-    slot1: Slot
-    slot2: Optional[Slot] = None
-    slot3: Optional[Slot] = None
+    slot1: Slot = Field(..., alias="inizio_1_fine_1")
+    slot2: Optional[Slot] = Field(None, alias="inizio_2_fine_2")
+    slot3: Optional[Slot] = Field(None, alias="inizio_3_fine_3")
     tipo: str
     note: Optional[str] = None
+
+    class Config:
+        allow_population_by_field_name = True
 
 class TurnoIn(TurnoBase):
     user_id: str
@@ -23,3 +26,4 @@ class TurnoOut(TurnoBase):
 
     class Config:
         orm_mode = True
+        allow_population_by_field_name = True


### PR DESCRIPTION
## Summary
- expose convenient slot properties on `Turno` ORM model
- map schema slots to those properties with `Field(..., alias)`
- use `allow_population_by_field_name` so models accept plain field names
- simplify weekly PDF creation using `TurnoOut.from_orm`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866d35b3d488323bb272bc012a6e636