### PR TITLE
Convert PDF id to UUID

### DIFF
--- a/app/crud/pdffile.py
+++ b/app/crud/pdffile.py
@@ -24,7 +24,7 @@ def create(db: Session, *, obj_in: PDFFileCreate, file: UploadFile) -> PDFFile:
     # Explicitly close the uploaded file to release resources
     file.file.close()
 
-    db_obj = PDFFile(title=obj_in.title, filename=fname)
+    db_obj = PDFFile(id=str(uuid.uuid4()), title=obj_in.title, filename=fname)
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)

--- a/app/models/pdffile.py
+++ b/app/models/pdffile.py
@@ -1,11 +1,12 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, String, DateTime
+import uuid
 from app.database import Base
 
 class PDFFile(Base):
     __tablename__ = "pdf_files"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
     title = Column(String, nullable=False)
     filename = Column(String, unique=True, nullable=False)
     uploaded_at = Column(DateTime, default=datetime.utcnow)

--- a/app/schemas/pdffile.py
+++ b/app/schemas/pdffile.py
@@ -8,7 +8,7 @@ class PDFFileCreate(PDFFileBase):
     pass
 
 class PDFFileResponse(PDFFileBase):
-    id: int
+    id: str
     filename: str
     uploaded_at: datetime
 

--- a/migrations/versions/0004_convert_pdf_files_id_to_uuid.py
+++ b/migrations/versions/0004_convert_pdf_files_id_to_uuid.py
@@ -1,0 +1,91 @@
+"""convert pdf_files.id from integer to string UUID"""
+
+from alembic import op
+import sqlalchemy as sa
+import uuid
+
+revision = '0004_convert_pdf_files_id_to_uuid'
+down_revision = '0003_add_nome_to_user'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'pdf_files_new',
+        sa.Column('id', sa.String(), primary_key=True),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('filename', sa.String(), nullable=False),
+        sa.Column('uploaded_at', sa.DateTime(), nullable=True),
+        sa.UniqueConstraint('filename'),
+    )
+
+    connection = op.get_bind()
+    old = sa.table(
+        'pdf_files',
+        sa.column('title', sa.String()),
+        sa.column('filename', sa.String()),
+        sa.column('uploaded_at', sa.DateTime()),
+    )
+    new = sa.table(
+        'pdf_files_new',
+        sa.column('id', sa.String()),
+        sa.column('title', sa.String()),
+        sa.column('filename', sa.String()),
+        sa.column('uploaded_at', sa.DateTime()),
+    )
+    rows = connection.execute(sa.select(old.c.title, old.c.filename, old.c.uploaded_at)).fetchall()
+    for row in rows:
+        connection.execute(
+            new.insert().values(
+                id=str(uuid.uuid4()),
+                title=row.title,
+                filename=row.filename,
+                uploaded_at=row.uploaded_at,
+            )
+        )
+
+    op.drop_index('ix_pdf_files_id', table_name='pdf_files')
+    op.drop_table('pdf_files')
+    op.rename_table('pdf_files_new', 'pdf_files')
+    op.create_index('ix_pdf_files_id', 'pdf_files', ['id'])
+
+
+def downgrade() -> None:
+    op.create_table(
+        'pdf_files_old',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('filename', sa.String(), nullable=False),
+        sa.Column('uploaded_at', sa.DateTime(), nullable=True),
+        sa.UniqueConstraint('filename'),
+    )
+
+    connection = op.get_bind()
+    new = sa.table(
+        'pdf_files',
+        sa.column('title', sa.String()),
+        sa.column('filename', sa.String()),
+        sa.column('uploaded_at', sa.DateTime()),
+    )
+    old = sa.table(
+        'pdf_files_old',
+        sa.column('id', sa.Integer()),
+        sa.column('title', sa.String()),
+        sa.column('filename', sa.String()),
+        sa.column('uploaded_at', sa.DateTime()),
+    )
+    rows = connection.execute(sa.select(new.c.title, new.c.filename, new.c.uploaded_at)).fetchall()
+    for row in rows:
+        connection.execute(
+            old.insert().values(
+                title=row.title,
+                filename=row.filename,
+                uploaded_at=row.uploaded_at,
+            )
+        )
+
+    op.drop_index('ix_pdf_files_id', table_name='pdf_files')
+    op.drop_table('pdf_files')
+    op.rename_table('pdf_files_old', 'pdf_files')
+    op.create_index('ix_pdf_files_id', 'pdf_files', ['id'])


### PR DESCRIPTION
## Summary
- migrate `pdf_files.id` from Integer to UUID
- update PDFFile model and schema
- generate UUIDs in pdf CRUD
- add Alembic migration for pdf id change

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866dbcf50988323b6d3ee9e3dac6bde