### PR TITLE
Switch PDF IDs to UUID

### DIFF
--- a/app/models/pdf_file.py
+++ b/app/models/pdf_file.py
@@ -1,11 +1,12 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, DateTime
+import uuid
+from sqlalchemy import Column, String, DateTime
 from app.database import Base
 
 class PDFFile(Base):
     __tablename__ = "pdf_files"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
     title = Column(String, nullable=False)
     filename = Column(String, unique=True, nullable=False)
     uploaded_at = Column(DateTime, default=datetime.utcnow)

--- a/app/schemas/pdf_file.py
+++ b/app/schemas/pdf_file.py
@@ -8,7 +8,7 @@ class PDFFileCreate(PDFFileBase):
     pass
 
 class PDFFileResponse(PDFFileBase):
-    id: int
+    id: str
     filename: str
     uploaded_at: datetime
 

--- a/migrations/versions/0004_pdf_file_uuid_id.py
+++ b/migrations/versions/0004_pdf_file_uuid_id.py
@@ -1,0 +1,53 @@
+"""convert pdf file id to uuid string"""
+
+from alembic import op
+import sqlalchemy as sa
+import uuid
+
+revision = '0004_pdf_file_uuid_id'
+down_revision = '0003_add_nome_to_user'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # add temporary uuid column
+    with op.batch_alter_table('pdf_files') as batch_op:
+        batch_op.add_column(sa.Column('id_new', sa.String(), nullable=True))
+
+    # populate with new uuids
+    results = conn.execute(sa.text('SELECT id FROM pdf_files')).fetchall()
+    for row in results:
+        conn.execute(
+            sa.text('UPDATE pdf_files SET id_new = :uuid WHERE id = :old_id'),
+            {'uuid': str(uuid.uuid4()), 'old_id': row[0]},
+        )
+
+    # drop old id and rename new column
+    with op.batch_alter_table('pdf_files') as batch_op:
+        batch_op.drop_index('ix_pdf_files_id')
+        batch_op.drop_column('id')
+        batch_op.alter_column('id_new', new_column_name='id', nullable=False)
+        batch_op.create_index('ix_pdf_files_id', ['id'])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    with op.batch_alter_table('pdf_files') as batch_op:
+        batch_op.drop_index('ix_pdf_files_id')
+        batch_op.add_column(sa.Column('id_old', sa.Integer(), autoincrement=True, nullable=True))
+
+    results = conn.execute(sa.text('SELECT id FROM pdf_files')).fetchall()
+    counter = 1
+    for row in results:
+        conn.execute(
+            sa.text('UPDATE pdf_files SET id_old = :new_id WHERE id = :uuid'),
+            {'new_id': counter, 'uuid': row[0]},
+        )
+        counter += 1
+
+    with op.batch_alter_table('pdf_files') as batch_op:
+        batch_op.drop_column('id')
+        batch_op.alter_column('id_old', new_column_name='id', nullable=False)
+        batch_op.create_index('ix_pdf_files_id', ['id'])

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -18,6 +18,9 @@ def test_upload_pdf_and_list(setup_db, tmp_path):
     body = res.json()
     assert body["title"] == "Doc"
     assert "filename" in body
+    # ensure id is a valid UUID string
+    from uuid import UUID
+    UUID(body["id"])
 
     list_res = client.get("/pdf/")
     assert list_res.status_code == 200


### PR DESCRIPTION
## Summary
- make PDFFile.id a UUID string
- update PDFFileResponse schema
- migrate existing PDF IDs to UUIDs
- validate returned PDF ID is a UUID

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866ddda31288323ba564a52934ae99c