### PR TITLE
Enable SQLite foreign keys

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,5 +1,5 @@
 import os
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -21,6 +21,13 @@ engine = create_engine(
     DATABASE_URL,
     connect_args=connect_args
 )
+
+if url.drivername.startswith("sqlite"):
+    @event.listens_for(engine, "connect")
+    def _enable_foreign_keys(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
 
 # Esporta gli argomenti di connessione per i test
 CONNECT_ARGS = connect_args

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,8 +1,30 @@
 import importlib
 import os
+import pytest
 
 def test_sqlite_connect_args(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "sqlite:///./test.db")
     db = importlib.reload(importlib.import_module("app.database"))
     assert db.CONNECT_ARGS == {"check_same_thread": False}
+
+
+def test_turno_invalid_user_fk(setup_db):
+    from datetime import date, time
+    from sqlalchemy.exc import IntegrityError
+    from app.database import SessionLocal
+    from app.models.turno import Turno
+
+    db = SessionLocal()
+    bad_turno = Turno(
+        user_id="missing",
+        giorno=date(2023, 1, 1),
+        inizio_1=time(8, 0, 0),
+        fine_1=time(12, 0, 0),
+        tipo="NORMALE",
+        note="",
+    )
+    db.add(bad_turno)
+    with pytest.raises(IntegrityError):
+        db.commit()
+    db.close()
 


### PR DESCRIPTION
## Summary
- ensure SQLite enforces foreign keys on connect
- test that invalid user id for `Turno` raises `IntegrityError`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866dd686ae08323a8652259b9cffe15