### PR TITLE
Add logging for PDF uploads

### DIFF
--- a/app/crud/pdf_file.py
+++ b/app/crud/pdf_file.py
@@ -1,10 +1,17 @@
 import os
 import uuid
 import shutil
+import logging
+from typing import Optional
+
 from sqlalchemy.orm import Session
 from fastapi import UploadFile
+
 from app.models.pdf_file import PDFFile
+from app.models.user import User
 from app.schemas.pdf_file import PDFFileCreate
+
+logger = logging.getLogger(__name__)
 
 
 def get_upload_root() -> str:
@@ -14,15 +21,37 @@ def get_upload_root() -> str:
     return root
 
 
-def create(db: Session, *, obj_in: PDFFileCreate, file: UploadFile) -> PDFFile:
+def create(
+    db: Session,
+    *,
+    obj_in: PDFFileCreate,
+    file: UploadFile,
+    user: Optional[User] = None,
+) -> PDFFile:
+    """Store ``file`` on disk and persist metadata in the database."""
     ext = os.path.splitext(file.filename)[1]
     fname = f"{uuid.uuid4()}{ext}"
     path = os.path.join(get_upload_root(), fname)
-    with open(path, "wb") as fp:
-        shutil.copyfileobj(file.file, fp)
-
-    # Explicitly close the uploaded file to release resources
-    file.file.close()
+    try:
+        with open(path, "wb") as fp:
+            shutil.copyfileobj(file.file, fp)
+        logger.info(
+            "Uploaded %s as %s for user=%s",
+            file.filename,
+            fname,
+            getattr(user, "email", "anonymous"),
+        )
+    except Exception as exc:  # pragma: no cover - unexpected I/O failure
+        logger.error(
+            "Failed uploading %s for user=%s: %s",
+            file.filename,
+            getattr(user, "email", "anonymous"),
+            exc,
+        )
+        raise
+    finally:
+        # Explicitly close the uploaded file to release resources
+        file.file.close()
 
     db_obj = PDFFile(title=obj_in.title, filename=fname)
     db.add(db_obj)
@@ -33,3 +62,34 @@ def create(db: Session, *, obj_in: PDFFileCreate, file: UploadFile) -> PDFFile:
 
 def get_multi(db: Session):
     return db.query(PDFFile).order_by(PDFFile.uploaded_at.desc()).all()
+
+
+def get_file_path(filename: str, user: Optional[User] = None) -> str:
+    """Return the full path for ``filename`` or raise ``FileNotFoundError``."""
+    from pathlib import Path
+
+    safe_name = Path(filename).name
+    if safe_name != filename:
+        logger.warning(
+            "Invalid filename requested %s by user=%s",
+            filename,
+            getattr(user, "email", "anonymous"),
+        )
+        raise FileNotFoundError(filename)
+
+    root = Path(get_upload_root())
+    path = root / safe_name
+    if not path.exists():
+        logger.warning(
+            "Requested file not found %s by user=%s",
+            safe_name,
+            getattr(user, "email", "anonymous"),
+        )
+        raise FileNotFoundError(filename)
+
+    logger.info(
+        "Retrieving file %s for user=%s",
+        safe_name,
+        getattr(user, "email", "anonymous"),
+    )
+    return str(path)

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,10 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import logging
 import os
+
+# Basic logging configuration
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
 from app.routes import (
     users,
     auth,

--- a/app/routes/pdf_files.py
+++ b/app/routes/pdf_files.py
@@ -2,10 +2,11 @@ from typing import List
 from fastapi import APIRouter, Depends, UploadFile, File, Form, HTTPException
 from sqlalchemy.orm import Session
 from fastapi.responses import FileResponse
-from app.dependencies import get_db
+
+from app.dependencies import get_db, get_optional_user
+from app.models.user import User
 from app.schemas.pdf_file import PDFFileCreate, PDFFileResponse
 from app.crud import pdf_file as crud_pdf_file
-import os
 
 router = APIRouter(prefix="/pdf", tags=["PDF"])
 
@@ -20,26 +21,29 @@ async def upload_pdf(
     title: str = Form(...),
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
+    current_user: User | None = Depends(get_optional_user),
 ):
     if file.content_type != "application/pdf":
         raise HTTPException(400, "Il file deve essere un PDF")
-    return crud_pdf_file.create(db, obj_in=PDFFileCreate(title=title), file=file)
+    return crud_pdf_file.create(
+        db, obj_in=PDFFileCreate(title=title), file=file, user=current_user
+    )
 
 
 @router.get("/{filename}")
-def get_pdf(filename: str):
+def get_pdf(
+    filename: str,
+    current_user: User | None = Depends(get_optional_user),
+):
     """Return a previously uploaded PDF by filename."""
+    from fastapi import HTTPException
     from pathlib import Path
-    from app.crud.pdf_file import get_upload_root
 
-    # Prevent path traversal attacks by stripping directory components
-    safe_name = Path(filename).name
-    if safe_name != filename:
-        # Invalid filename with path components
-        raise HTTPException(status_code=404)
+    try:
+        path = crud_pdf_file.get_file_path(filename, user=current_user)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404) from None
 
-    root = Path(get_upload_root())
-    path = root / safe_name
-    if not path.exists():
-        raise HTTPException(status_code=404)
-    return FileResponse(str(path), media_type="application/pdf", filename=safe_name)
+    return FileResponse(
+        path, media_type="application/pdf", filename=Path(path).name
+    )


### PR DESCRIPTION
## Summary
- set up global logging config
- add logger usage in `crud/pdf_file` for upload and retrieval events
- accept optional user in PDF routes and CRUD
- log file retrieval

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866dfb87e088323b4df8d1bcc2aee78