### PR TITLE
Add configurable max PDF size check

### DIFF
--- a/app/routes/pdf_files.py
+++ b/app/routes/pdf_files.py
@@ -23,6 +23,17 @@ async def upload_pdf(
 ):
     if file.content_type != "application/pdf":
         raise HTTPException(400, "Il file deve essere un PDF")
+    max_size = os.getenv("MAX_PDF_SIZE")
+    if max_size:
+        try:
+            limit = int(max_size)
+        except ValueError:
+            limit = 0
+        if limit > 0:
+            chunk = await file.read(limit + 1)
+            if len(chunk) > limit:
+                raise HTTPException(status_code=413, detail="File too large")
+            await file.seek(0)
     return crud_pdf_file.create(db, obj_in=PDFFileCreate(title=title), file=file)
 
 


### PR DESCRIPTION
## Summary
- enforce a configurable file size limit for PDF uploads
- test max PDF size handling

## Testing
- `black --check app/routes/pdf_files.py tests/test_pdfs.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866dfb784288323afb62dff0053930d