### PR TITLE
Add configurable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 - `G_SHIFT_CAL_ID` – ID of the Google Calendar used for shift syncs.
 - `CORS_ORIGINS` – (optional) comma separated list of allowed origins for
   cross-origin requests. Defaults to `"*"`.
+- `LOG_LEVEL` – (optional) Python log level for application logging. Defaults
+  to `"INFO"`.
 
 ## Database migrations
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import logging
 import os
 from app.routes import (
     users,
@@ -16,6 +17,9 @@ from app.routes import imports
 
 # Enable automatic redirect so both `/path` and `/path/` work
 # Tests continue to use the canonical routes defined in the routers
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+
 app = FastAPI()
 
 # Database tables are managed with Alembic migrations.


### PR DESCRIPTION
## Summary
- add a `LOG_LEVEL` environment variable to control log verbosity
- configure logging before creating the FastAPI instance

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866e48fe754832389cec3c6b3993d35