### PR TITLE
Add user info to PDF upload logs

### DIFF
--- a/app/routes/pdf_files.py
+++ b/app/routes/pdf_files.py
@@ -2,7 +2,8 @@ from typing import List
 from fastapi import APIRouter, Depends, UploadFile, File, Form, HTTPException
 from sqlalchemy.orm import Session
 from fastapi.responses import FileResponse
-from app.dependencies import get_db
+from app.dependencies import get_db, get_optional_user
+from app.models.user import User
 from app.schemas.pdf_file import PDFFileCreate, PDFFileResponse
 from app.crud import pdf_file as crud_pdf_file
 import os
@@ -20,10 +21,13 @@ async def upload_pdf(
     title: str = Form(...),
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
+    user: User | None = Depends(get_optional_user),
 ):
     if file.content_type != "application/pdf":
         raise HTTPException(400, "Il file deve essere un PDF")
-    return await crud_pdf_file.create(db, obj_in=PDFFileCreate(title=title), file=file)
+    return await crud_pdf_file.create(
+        db, obj_in=PDFFileCreate(title=title), file=file, user=user
+    )
 
 
 @router.get("/{filename}")


### PR DESCRIPTION
## Summary
- extend `crud.pdf_file.create` to accept an optional user
- log the uploader's email or `anonymous` on success or failure
- allow `/pdf/` uploads to use `get_optional_user` and pass the user through

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866e4997a048323847ddba4fe570441