### PR TITLE
Fix Pydantic response models

### DIFF
--- a/app/routes/orari.py
+++ b/app/routes/orari.py
@@ -61,7 +61,10 @@ def week_pdf(
 
     turni = crud_turno.list_between(db, start, end)
 
-    rows = [jsonable_encoder(TurnoOut.from_orm(t)) for t in turni]
+    rows = [
+        jsonable_encoder(TurnoOut.model_validate(t, from_attributes=True))
+        for t in turni
+    ]
 
     pdf_path, html_path = df_to_pdf(rows)
     background_tasks.add_task(os.remove, pdf_path)

--- a/app/schemas/determinazione.py
+++ b/app/schemas/determinazione.py
@@ -1,12 +1,18 @@
 from pydantic import BaseModel
 from datetime import datetime
+
+
 class DeterminazioneCreate(BaseModel):
     capitolo: str
     numero: str
     descrizione: str
     somma: float
     scadenza: datetime
+
+
 class DeterminazioneResponse(DeterminazioneCreate):
     id: str
-    class Config:
-        orm_mode = True
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/schemas/event.py
+++ b/app/schemas/event.py
@@ -1,12 +1,18 @@
 from pydantic import BaseModel
 from datetime import datetime
+
+
 class EventCreate(BaseModel):
     titolo: str
     descrizione: str | None = None
     data_ora: datetime
     is_public: bool = False
+
+
 class EventResponse(EventCreate):
     id: str
     user_id: str
-    class Config:
-        orm_mode = True
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/schemas/pdf_file.py
+++ b/app/schemas/pdf_file.py
@@ -1,16 +1,20 @@
 from datetime import datetime
 from pydantic import BaseModel
 
+
 class PDFFileBase(BaseModel):
     title: str
 
+
 class PDFFileCreate(PDFFileBase):
     pass
+
 
 class PDFFileResponse(PDFFileBase):
     id: str
     filename: str
     uploaded_at: datetime
 
-    class Config:
-        orm_mode = True
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/schemas/todo.py
+++ b/app/schemas/todo.py
@@ -1,11 +1,16 @@
 from pydantic import BaseModel
 from datetime import datetime
+
+
 class ToDoCreate(BaseModel):
     descrizione: str
     scadenza: datetime
+
+
 class ToDoResponse(ToDoCreate):
     id: str
     user_id: str
-    class Config:
-        orm_mode = True
 
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/schemas/turno.py
+++ b/app/schemas/turno.py
@@ -1,6 +1,8 @@
 from datetime import date, time
 from pydantic import BaseModel
 from typing import Optional
+from uuid import UUID
+
 
 class TurnoBase(BaseModel):
     giorno: date
@@ -13,12 +15,15 @@ class TurnoBase(BaseModel):
     tipo: str
     note: Optional[str] = None
 
+
 class TurnoIn(TurnoBase):
     user_id: str
 
-class TurnoOut(TurnoBase):
-    id: str
-    user_id: str
 
-    class Config:
-        orm_mode = True
+class TurnoOut(TurnoBase):
+    id: UUID
+    user_id: UUID
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
 from app.schemas.turno import TurnoOut
+
+
 class UserCreate(BaseModel):
     email: str
     password: str
@@ -9,10 +11,14 @@ class UserCreate(BaseModel):
 class UserCredentials(BaseModel):
     email: str
     password: str
+
+
 class UserResponse(BaseModel):
     id: str
     email: str
     nome: str
     turni: list[TurnoOut] = []
-    class Config:
-        orm_mode = True
+
+    model_config = {
+        "from_attributes": True,
+    }


### PR DESCRIPTION
## Summary
- enable Pydantic v2 attribute parsing for all response schemas
- update routes to use `model_validate(..., from_attributes=True)`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866f36e9abc832384288dfbe5c7fcc0