### PR TITLE
Implement /users/me endpoint

### DIFF
--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from app.dependencies import get_db
-from app.schemas.user import UserCreate, UserResponse
+from app.dependencies import get_db, get_current_user
+from app.schemas.user import UserCreate, UserResponse, UserOut
 from app.crud import user
+from app.models.user import User
 router = APIRouter(prefix="/users", tags=["Users"])
 
 # ───── nuovo endpoint GET /users/ ─────
@@ -27,4 +28,11 @@ def get_user_by_email_route(email: str, db: Session = Depends(get_db)):
     if not result:
         raise HTTPException(status_code=404, detail="User not found")
     return result
+# ───────────────────────────────────────────────
+
+
+@router.get("/me", response_model=UserOut)
+def read_current_user(current_user: User = Depends(get_current_user)):
+    """Restituisce i dati dell'utente autenticato (dal token JWT)."""
+    return current_user
 # ───────────────────────────────────────────────

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from uuid import UUID
 from app.schemas.turno import TurnoOut
 
 
@@ -11,6 +12,16 @@ class UserCreate(BaseModel):
 class UserCredentials(BaseModel):
     email: str
     password: str
+
+
+class UserOut(BaseModel):
+    id: UUID
+    email: str
+    nome: str
+
+    model_config = {
+        "from_attributes": True,
+    }
 
 
 class UserResponse(BaseModel):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -97,3 +97,12 @@ def test_get_user_by_email_not_found():
     response = client.get("/users/by-email", params={"email": "missing@example.com"})
     assert response.status_code == 404
 
+
+def test_get_current_user(setup_db):
+    headers, user_id = auth_user("me@example.com")
+    response = client.get("/users/me", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == user_id
+    assert data["email"] == "me@example.com"
+


### PR DESCRIPTION
## Summary
- add `UserOut` schema
- expose `/users/me` to return the authenticated user
- test the new route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866f684680c8323836f41cec51c389c