### PR TITLE
Remove unused python-dotenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 fastapi
 uvicorn[standard]
 sqlalchemy
-python-dotenv
 passlib[bcrypt]
 bcrypt<4.0
 python-jose[cryptography]


### PR DESCRIPTION
## Summary
- clean up python-dotenv from requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6867134e79e48323bdbe1881aac2afac