### PR TITLE
Sanitize example secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
-DATABASE_URL=postgresql://neondb_owner:npg_fDvE2opz7unT@ep-nameless-dream-abij1vml-pooler.eu-west-2.aws.neon.tech/neondb
-SECRET_KEY=1234
+DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+SECRET_KEY=your-secret-key
 ALGORITHM=HS256
 
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 PDF_UPLOAD_ROOT=uploads/pdfs
-GOOGLE_CREDENTIALS_JSON=/etc/keys/service_account.json
-G_EVENT_CAL_ID=eventi_pl@group.calendar.google.com      # calendario Eventi
-G_SHIFT_CAL_ID=turni_pl@group.calendar.google.com      # calendario Turni
+GOOGLE_CREDENTIALS_JSON=/path/to/service_account.json
+G_EVENT_CAL_ID=your_event_calendar@group.calendar.google.com      # calendario Eventi
+G_SHIFT_CAL_ID=your_shift_calendar@group.calendar.google.com      # calendario Turni
 
-GOOGLE_CALENDAR_ID=
+GOOGLE_CALENDAR_ID=your_calendar_id
 CORS_ORIGINS=https://example.com    # comma separated origins


### PR DESCRIPTION
## Summary
- replace database URL with placeholder values
- use obviously fake example credentials

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6867146f055c8323b9928b81cd817326