### PR TITLE
Enable automatic migrations

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -38,10 +38,10 @@ jobs:
     - name: Install dependencies
       run: pip install -r requirements.txt -r requirements-dev.txt
 
-    # - name: Run migrations
-    #   run: alembic upgrade head
-    #   env:
-    #     DATABASE_URL: ${{ env.DATABASE_URL }}
+    - name: Run migrations
+      run: alembic upgrade head
+      env:
+        DATABASE_URL: ${{ env.DATABASE_URL }}
 
     - name: Deploy to Render
       run: |


### PR DESCRIPTION
## Summary
- enable Alembic migrations in the deployment workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68671589d1dc8323b29b36f20c572ab6