### PR TITLE
Add broader error handling to import_xlsx

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, UploadFile, Depends, BackgroundTasks, HTTPException
+import traceback
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 import tempfile
@@ -19,28 +20,34 @@ async def import_xlsx(
     db: Session = Depends(get_db),
 ):
     """Import Excel shifts, sync them and return a PDF summary."""
-    # 1 – save temp file
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
-        tmp.write(await file.read())
-        tmp_path = tmp.name
-
-    # 2 – parse Excel -> TurnoIn payloads
     try:
-        rows = parse_excel(tmp_path, db)
+        # 1 – save temp file
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
+            tmp.write(await file.read())
+            tmp_path = tmp.name
+
+        # 2 – parse Excel -> TurnoIn payloads
+        try:
+            rows = parse_excel(tmp_path, db)
+        except HTTPException:
+            os.remove(tmp_path)
+            raise
+
+        # 3 – store/update each shift (DB + Google Calendar)
+        for payload in rows:
+            crud_turno.upsert_turno(db, TurnoIn(**payload))
+
+        # 4 – generate PDF summary
+        pdf_path, html_path = df_to_pdf(rows)
+        background_tasks.add_task(os.remove, pdf_path)
+        background_tasks.add_task(os.remove, html_path)
+        background_tasks.add_task(os.remove, tmp_path)
+        return FileResponse(pdf_path, filename="turni_settimana.pdf")
     except HTTPException:
-        os.remove(tmp_path)
         raise
-
-    # 3 – store/update each shift (DB + Google Calendar)
-    for payload in rows:
-        crud_turno.upsert_turno(db, TurnoIn(**payload))
-
-    # 4 – generate PDF summary
-    pdf_path, html_path = df_to_pdf(rows)
-    background_tasks.add_task(os.remove, pdf_path)
-    background_tasks.add_task(os.remove, html_path)
-    background_tasks.add_task(os.remove, tmp_path)
-    return FileResponse(pdf_path, filename="turni_settimana.pdf")
+    except Exception as e:
+        traceback.print_exc()
+        raise HTTPException(500, f"Errore import: {e}")
 
 
 @router.post("/excel", include_in_schema=False)


### PR DESCRIPTION
## Summary
- import traceback in imports route
- wrap `import_xlsx` body in a try/except
- on unexpected errors print traceback and raise HTTP 500

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6867908bfe708323883dd07ed94ec2c8