### PR TITLE
Centralize app configuration

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+import os
+
+@dataclass
+class Settings:
+    DATABASE_URL: str
+    SECRET_KEY: str
+    ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    PDF_UPLOAD_ROOT: str = "uploads/pdfs"
+    GOOGLE_CREDENTIALS_JSON: str | None = None
+    G_EVENT_CAL_ID: str | None = None
+    G_SHIFT_CAL_ID: str | None = None
+    GOOGLE_CALENDAR_ID: str | None = None
+    CORS_ORIGINS: str = "*"
+    LOG_LEVEL: str = "INFO"
+
+
+def load_settings() -> Settings:
+    missing = []
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        missing.append("DATABASE_URL")
+    secret_key = os.getenv("SECRET_KEY")
+    if not secret_key:
+        missing.append("SECRET_KEY")
+    if missing:
+        raise RuntimeError("Missing required environment variables: " + ", ".join(missing))
+
+    return Settings(
+        DATABASE_URL=database_url,
+        SECRET_KEY=secret_key,
+        ALGORITHM=os.getenv("ALGORITHM", "HS256"),
+        ACCESS_TOKEN_EXPIRE_MINUTES=int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30")),
+        PDF_UPLOAD_ROOT=os.getenv("PDF_UPLOAD_ROOT", "uploads/pdfs"),
+        GOOGLE_CREDENTIALS_JSON=os.getenv("GOOGLE_CREDENTIALS_JSON"),
+        G_EVENT_CAL_ID=os.getenv("G_EVENT_CAL_ID"),
+        G_SHIFT_CAL_ID=os.getenv("G_SHIFT_CAL_ID"),
+        GOOGLE_CALENDAR_ID=os.getenv("GOOGLE_CALENDAR_ID"),
+        CORS_ORIGINS=os.getenv("CORS_ORIGINS", "*"),
+        LOG_LEVEL=os.getenv("LOG_LEVEL", "INFO"),
+    )
+
+
+settings = load_settings()
+
+
+def reload_settings() -> None:
+    """Reload settings from environment variables (mainly for tests)."""
+    global settings
+    settings = load_settings()

--- a/app/crud/pdf_file.py
+++ b/app/crud/pdf_file.py
@@ -6,13 +6,14 @@ from fastapi import UploadFile, HTTPException
 import aiofiles
 from app.models.pdf_file import PDFFile
 from app.schemas.pdf_file import PDFFileCreate
+from app.config import settings
 
 logger = logging.getLogger(__name__)
 
 
 def get_upload_root() -> str:
     """Return the path where PDF files should be stored."""
-    root = os.getenv("PDF_UPLOAD_ROOT", "uploads/pdfs")
+    root = settings.PDF_UPLOAD_ROOT
     os.makedirs(root, exist_ok=True)
     return root
 

--- a/app/database.py
+++ b/app/database.py
@@ -1,13 +1,11 @@
-import os
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from app.config import settings
 
-# Recupera la URL del database da variabile d'ambiente
-DATABASE_URL = os.getenv("DATABASE_URL")
-if not DATABASE_URL:
-    raise RuntimeError("DATABASE_URL environment variable not set")
+# Recupera la URL del database dal modulo di configurazione
+DATABASE_URL = settings.DATABASE_URL
 
 # Determina gli argomenti di connessione in base allo schema della URL
 url = make_url(DATABASE_URL)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -3,7 +3,7 @@ from typing import Generator
 from sqlalchemy.orm import Session
 from fastapi import Depends, Header, HTTPException
 from jose import jwt, JWTError
-import os
+from app.config import settings
 
 from .database import SessionLocal
 from .models.user import User
@@ -26,10 +26,10 @@ def get_current_user(
         raise HTTPException(status_code=401, detail="Invalid authorization header")
 
     token = authorization.split(" ", 1)[1]
-    secret = os.getenv("SECRET_KEY")
+    secret = settings.SECRET_KEY
     if not secret:
         raise HTTPException(status_code=500, detail="Secret key not configured")
-    algorithm = os.getenv("ALGORITHM", "HS256")
+    algorithm = settings.ALGORITHM
 
     try:
         payload = jwt.decode(token, secret, algorithms=[algorithm])

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import logging
-import os
+from app.config import settings
 from app.routes import (
     users,
     auth,
@@ -17,7 +17,7 @@ from app.routes import imports
 
 # Enable automatic redirect so both `/path` and `/path/` work
 # Tests continue to use the canonical routes defined in the routers
-log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+log_level = settings.LOG_LEVEL.upper()
 logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
 
 app = FastAPI()
@@ -25,7 +25,7 @@ app = FastAPI()
 # Database tables are managed with Alembic migrations.
 # Tests create tables manually using `Base.metadata.create_all()`.
 
-origins = os.getenv("CORS_ORIGINS", "*")
+origins = settings.CORS_ORIGINS
 if origins == "*":
     allow_origins = ["*"]
 else:

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -4,15 +4,15 @@ from app.dependencies import get_db
 from app.schemas.user import UserCreate, UserCredentials
 from app.crud import user
 from jose import jwt
-import os
+from app.config import settings
 import datetime
 
-SECRET_KEY = os.getenv("SECRET_KEY")
+SECRET_KEY = settings.SECRET_KEY
 if not SECRET_KEY:
     raise RuntimeError("SECRET_KEY environment variable not set")
 
-ALGORITHM = os.getenv("ALGORITHM", "HS256")
-ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30"))
+ALGORITHM = settings.ALGORITHM
+ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 router = APIRouter(tags=["Auth"])
 
 @router.post("/login")

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy import text
-import os
+from app.config import settings
 
 from app.dependencies import get_db
 
@@ -11,9 +11,9 @@ router = APIRouter(tags=["Health"])
 @router.get("/health")
 def health_check(db: Session = Depends(get_db)):
     """Check environment and database connectivity."""
-    if not os.getenv("DATABASE_URL"):
+    if not settings.DATABASE_URL:
         raise HTTPException(status_code=500, detail="DATABASE_URL not configured")
-    if not os.getenv("SECRET_KEY"):
+    if not settings.SECRET_KEY:
         raise HTTPException(status_code=500, detail="SECRET_KEY not configured")
     db.execute(text("SELECT 1"))
     return {"status": "ok"}

--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -9,9 +9,10 @@ Richiede:
   G_SHIFT_CAL_ID=…@group.calendar.google.com
 """
 
-import os
 from datetime import date, time, datetime
 from functools import lru_cache
+from app.config import settings
+import os
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
@@ -22,14 +23,14 @@ import googleapiclient.errors as gerr
 def get_client():
     """Return a Google Calendar client built from service account credentials."""
     creds = service_account.Credentials.from_service_account_file(
-        os.getenv("GOOGLE_CREDENTIALS_JSON"),
+        settings.GOOGLE_CREDENTIALS_JSON,
         scopes=["https://www.googleapis.com/auth/calendar"],
     )
     return build("calendar", "v3", credentials=creds)
 
 # ------------------------------------------------------------------- calendar ID
-EVENT_CAL_ID = os.getenv("G_EVENT_CAL_ID")   # già in uso per gli altri eventi
-SHIFT_CAL_ID = os.getenv("G_SHIFT_CAL_ID")   # nuovo calendario “Turni di Servizio”
+EVENT_CAL_ID = settings.G_EVENT_CAL_ID   # già in uso per gli altri eventi
+SHIFT_CAL_ID = settings.G_SHIFT_CAL_ID   # nuovo calendario “Turni di Servizio”
 
 # ------------------------------------------------------------------- utilità
 def iso_dt(d: date, t: time) -> str:

--- a/app/services/google_calendar.py
+++ b/app/services/google_calendar.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import os
 import json
 from datetime import datetime, timedelta
 from typing import Any
 
 from fastapi import HTTPException
+from app.config import settings
+import os
 
 
 def list_upcoming_events(days: int) -> list[dict[str, Any]]:
@@ -15,8 +16,8 @@ def list_upcoming_events(days: int) -> list[dict[str, Any]]:
     environment variables. When they are missing, an empty list is returned.
     ``data_ora`` fields in the returned dictionaries are ``datetime`` objects.
     """
-    creds_json = os.getenv("GOOGLE_CREDENTIALS_JSON")
-    calendar_id = os.getenv("GOOGLE_CALENDAR_ID")
+    creds_json = settings.GOOGLE_CREDENTIALS_JSON
+    calendar_id = settings.GOOGLE_CALENDAR_ID
     if not creds_json or not calendar_id:
         return []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
 
 from app.database import Base, engine
+from app import config
 
 @pytest.fixture(autouse=True)
 def setup_db():
@@ -22,9 +23,10 @@ def setup_db():
 @pytest.fixture(autouse=True)
 def setup_upload_dir(tmp_path):
     upload_dir = tmp_path / "pdfs"
-    os.environ["PDF_UPLOAD_ROOT"] = str(upload_dir)
+    original = config.settings.PDF_UPLOAD_ROOT
+    config.settings.PDF_UPLOAD_ROOT = str(upload_dir)
 
-    # Reload pdf_file module so it picks up the new environment variable
+    # Reload pdf_file module so it picks up the new setting
     import app.crud.pdf_file as pdf_file
     pdf_file = importlib.reload(pdf_file)
 
@@ -34,6 +36,7 @@ def setup_upload_dir(tmp_path):
 
     yield
     shutil.rmtree(str(upload_dir), ignore_errors=True)
+    config.settings.PDF_UPLOAD_ROOT = original
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,10 +1,12 @@
 import importlib
-import os
 import pytest
+from app import config
 
-def test_sqlite_connect_args(monkeypatch):
-    monkeypatch.setenv("DATABASE_URL", "sqlite:///./test.db")
+def test_sqlite_connect_args():
+    original = config.settings.DATABASE_URL
+    config.settings.DATABASE_URL = "sqlite:///./test.db"
     db = importlib.reload(importlib.import_module("app.database"))
+    config.settings.DATABASE_URL = original
     assert db.CONNECT_ARGS == {"check_same_thread": False}
 
 

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
-import os
 from pathlib import Path
 from unittest.mock import patch
+from app import config
 
 from app.main import app
 
@@ -66,7 +66,7 @@ def test_delete_pdf_removes_file_and_record(setup_db, tmp_path):
         )
     fname = res.json()["filename"]
 
-    upload_root = os.environ["PDF_UPLOAD_ROOT"]
+    upload_root = config.settings.PDF_UPLOAD_ROOT
     stored = Path(upload_root) / fname
     assert stored.exists()
 
@@ -101,5 +101,5 @@ def test_upload_write_error_returns_500(setup_db, tmp_path):
 
     assert res.status_code == 500
     assert client.get("/pdf/").json() == []
-    upload_root = os.environ["PDF_UPLOAD_ROOT"]
+    upload_root = config.settings.PDF_UPLOAD_ROOT
     assert list(Path(upload_root).iterdir()) == []


### PR DESCRIPTION
## Summary
- add `app.config` module loading environment variables once
- use configuration settings in database, auth, dependencies, services, and main
- update tests to patch centralized configuration values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6867908f0d4883239ff9944ac8e9fec4