### PR TITLE
Update supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a FastAPI backend used by Segretaria Digitale.
 
 ## Setup
 
-1. Ensure you have **Python 3.10+** installed.
+1. Ensure you have **Python 3.10–3.11** installed.
 2. Create a virtual environment and install dependencies (including `httpx`,
    `pandas`, `openpyxl` and `pdfkit`):
    ```bash


### PR DESCRIPTION
## Summary
- clarify Python compatibility range in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt` *(fails: network access needed for packages)*

------
https://chatgpt.com/codex/tasks/task_e_6867eaf173688323aabd67056c4c797e