### PR TITLE
Update pandas to >=2.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y wkhtmltopdf \
 WORKDIR /app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip cache purge || true && pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ alembic==1.13.1
 python-multipart==0.0.9
 google-api-python-client==2.126.0
 google-auth==2.28.2
-pandas==2.1.4
+pandas>=2.2.3
 openpyxl==3.1.2
 pdfkit==1.0.0
 aiofiles==23.2.1


### PR DESCRIPTION
## Summary
- upgrade pandas to a Python 3.13 compatible release
- purge pip cache before installing requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6867ee34a1748323b6165da12eb8a89d