### PR TITLE
Return 401 for missing Authorization header

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,7 +1,7 @@
 from typing import Generator
 
 from sqlalchemy.orm import Session
-from fastapi import Depends, Header, HTTPException
+from fastapi import Depends, Header, HTTPException, status
 from jose import jwt, JWTError
 from app.config import settings
 
@@ -19,9 +19,14 @@ def get_db() -> Generator[Session, None, None]:
 
 def get_current_user(
     db: Session = Depends(get_db),
-    authorization: str = Header(..., alias="Authorization"),
+    authorization: str | None = Header(None, alias="Authorization"),
 ) -> User:
     """Return the authenticated ``User`` based on the JWT token."""
+    if authorization is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authorization header missing",
+        )
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid authorization header")
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -106,3 +106,9 @@ def test_get_current_user(setup_db):
     assert data["id"] == user_id
     assert data["email"] == "me@example.com"
 
+
+def test_get_current_user_missing_header():
+    response = client.get("/users/me")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authorization header missing"
+


### PR DESCRIPTION
## Summary
- ensure `Authorization` header is optional in `get_current_user`
- raise HTTP 401 when no authorization header is supplied
- test 401 error for `/users/me` without credentials

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68682e31ea088323b0754d6f3d891a6f