### PR TITLE
Remove duplicate aiofiles from dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 pytest==8.2.0
 flake8==6.1.0
 black==24.4.2
-aiofiles==23.2.1


### PR DESCRIPTION
## Summary
- remove duplicated `aiofiles` dependency from `requirements-dev.txt` because it's already in `requirements.txt`

## Testing
- `pytest -k health -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6868f0c3056c832387c4e9b793e107a7