### PR TITLE
Validate PDF extension before upload

### DIFF
--- a/app/routes/pdf_files.py
+++ b/app/routes/pdf_files.py
@@ -27,6 +27,8 @@ async def upload_pdf(
 ):
     if file.content_type != "application/pdf":
         raise HTTPException(400, "Il file deve essere un PDF")
+    if not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(400, "Il file deve avere estensione .pdf")
     return await crud_pdf_file.create(db, obj_in=PDFFileCreate(title=title), file=file)
 
 

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -45,6 +45,18 @@ def test_upload_invalid_content_type(setup_db, tmp_path):
     assert res.status_code == 400
 
 
+def test_upload_invalid_extension(setup_db, tmp_path):
+    malicious = tmp_path / "malicious.txt"
+    malicious.write_bytes(b"%PDF-1.4 test")
+    with open(malicious, "rb") as fh:
+        res = client.post(
+            "/pdf/",
+            data={"title": "Bad"},
+            files={"file": ("malicious.txt", fh, "application/pdf")},
+        )
+    assert res.status_code == 400
+
+
 def test_get_pdf_not_found(setup_db):
     res = client.get("/pdf/missing.pdf")
     assert res.status_code == 404


### PR DESCRIPTION
## Summary
- validate `.pdf` extension in the upload endpoint
- reject files without `.pdf` extension even if content type is `application/pdf`
- test uploading a malicious `.txt` file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -q -r requirements.txt -r requirements-dev.txt` *(fails: Could not fetch packages because internet access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6868f0c58f988323ba6b99dfea02bff0