### PR TITLE
Remove unused os imports

### DIFF
--- a/app/routes/pdf_files.py
+++ b/app/routes/pdf_files.py
@@ -7,7 +7,6 @@ from app.dependencies import get_db, get_optional_user
 from app.models.user import User
 from app.schemas.pdf_file import PDFFileCreate, PDFFileResponse
 from app.crud import pdf_file as crud_pdf_file
-import os
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -12,7 +12,6 @@ Richiede:
 from datetime import date, time, datetime
 from functools import lru_cache
 from app.config import settings
-import os
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build


### PR DESCRIPTION
## Summary
- remove unused os imports from pdf file routes and gcal service

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f548d5c08323888c4497166b5a68