### PR TITLE
Format codebase with black

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import os
 
+
 @dataclass
 class Settings:
     DATABASE_URL: str
@@ -25,7 +26,9 @@ def load_settings() -> Settings:
     if not secret_key:
         missing.append("SECRET_KEY")
     if missing:
-        raise RuntimeError("Missing required environment variables: " + ", ".join(missing))
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )
 
     return Settings(
         DATABASE_URL=database_url,

--- a/app/crud/determinazione.py
+++ b/app/crud/determinazione.py
@@ -18,7 +18,9 @@ def get_determinazioni(db: Session):
 
 def update_determinazione(db: Session, determinazione_id: str, data):
     """Update an existing ``Determinazione`` or return ``None`` if absent."""
-    db_det = db.query(Determinazione).filter(Determinazione.id == determinazione_id).first()
+    db_det = (
+        db.query(Determinazione).filter(Determinazione.id == determinazione_id).first()
+    )
     if not db_det:
         return None
     for key, value in data.dict().items():
@@ -30,7 +32,9 @@ def update_determinazione(db: Session, determinazione_id: str, data):
 
 def delete_determinazione(db: Session, determinazione_id: str):
     """Delete a ``Determinazione`` by id if present and return it."""
-    db_det = db.query(Determinazione).filter(Determinazione.id == determinazione_id).first()
+    db_det = (
+        db.query(Determinazione).filter(Determinazione.id == determinazione_id).first()
+    )
     if db_det:
         db.delete(db_det)
         db.commit()

--- a/app/crud/event.py
+++ b/app/crud/event.py
@@ -22,7 +22,9 @@ def get_events(db: Session, user: User | None = None):
 
 def update_event(db: Session, event_id: str, data, user: User):
     """Update an ``Event`` owned by ``user`` or return ``None`` if missing."""
-    db_event = db.query(Event).filter(Event.id == event_id, Event.user_id == user.id).first()
+    db_event = (
+        db.query(Event).filter(Event.id == event_id, Event.user_id == user.id).first()
+    )
     if not db_event:
         return None
     for key, value in data.dict().items():
@@ -34,7 +36,9 @@ def update_event(db: Session, event_id: str, data, user: User):
 
 def delete_event(db: Session, event_id: str, user: User):
     """Delete the event owned by ``user`` with ``event_id`` if it exists."""
-    db_event = db.query(Event).filter(Event.id == event_id, Event.user_id == user.id).first()
+    db_event = (
+        db.query(Event).filter(Event.id == event_id, Event.user_id == user.id).first()
+    )
     if db_event:
         db.delete(db_event)
         db.commit()

--- a/app/crud/todo.py
+++ b/app/crud/todo.py
@@ -36,4 +36,3 @@ def delete_todo(db: Session, todo_id: str, user: User):
         db.delete(db_todo)
         db.commit()
     return db_todo
-

--- a/app/crud/turno.py
+++ b/app/crud/turno.py
@@ -15,10 +15,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from app.models.turno import Turno          # modello ORM
+from app.models.turno import Turno  # modello ORM
 from app.models.user import User
-from app.schemas.turno import TurnoIn       # Pydantic (input)
+from app.schemas.turno import TurnoIn  # Pydantic (input)
 from app.services import gcal
+
 
 # ------------------------------------------------------------------------------
 def upsert_turno(db: Session, payload: TurnoIn) -> Turno:
@@ -48,13 +49,13 @@ def upsert_turno(db: Session, payload: TurnoIn) -> Turno:
     rec.inizio_3 = payload.inizio_3
     rec.fine_3 = payload.fine_3
 
-    rec.tipo = payload.tipo            # NORMALE | STRAORD | FERIE
+    rec.tipo = payload.tipo  # NORMALE | STRAORD | FERIE
     rec.note = payload.note
 
     # 4. salva su database
     db.add(rec)
     db.commit()
-    db.refresh(rec)                    # ottieni id definitivo
+    db.refresh(rec)  # ottieni id definitivo
 
     # 5. sincronizza l’evento Google Calendar
     try:
@@ -98,11 +99,7 @@ def get_turni(db: Session, user: User) -> list[Turno]:
 # ------------------------------------------------------------------------------
 def list_all(db: Session) -> list[Turno]:
     """Return all ``Turno`` records in the database ordered by date."""
-    return (
-        db.query(Turno)
-        .order_by(Turno.giorno.asc())
-        .all()
-    )
+    return db.query(Turno).order_by(Turno.giorno.asc()).all()
 
 
 # ------------------------------------------------------------------------------

--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -39,8 +39,5 @@ def verify_password(plain_password, hashed_password):
 def list_users(db: Session):
     """Restituisce tutti gli utenti ordinati per nome con i turni caricati."""
     return (
-        db.query(User)
-        .options(joinedload(User.turni))
-        .order_by(User.nome.asc())
-        .all()
+        db.query(User).options(joinedload(User.turni)).order_by(User.nome.asc()).all()
     )

--- a/app/database.py
+++ b/app/database.py
@@ -15,27 +15,22 @@ else:
     connect_args = {"sslmode": "require"}
 
 # Crea il motore SQLAlchemy con gli argomenti appropriati
-engine = create_engine(
-    DATABASE_URL,
-    connect_args=connect_args
-)
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
 
 if url.drivername.startswith("sqlite"):
+
     @event.listens_for(engine, "connect")
     def _enable_foreign_keys(dbapi_connection, connection_record):
         cursor = dbapi_connection.cursor()
         cursor.execute("PRAGMA foreign_keys=ON")
         cursor.close()
 
+
 # Esporta gli argomenti di connessione per i test
 CONNECT_ARGS = connect_args
 
 # Configura la session factory
-SessionLocal = sessionmaker(
-    autocommit=False,
-    autoflush=False,
-    bind=engine
-)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # Base per i modelli ORM
 Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -52,4 +52,5 @@ app.include_router(imports.router)
 
 from app.crud.pdf_file import get_upload_root
 from fastapi.staticfiles import StaticFiles
+
 app.mount("/uploads", StaticFiles(directory=get_upload_root()), name="uploads")

--- a/app/models/determinazione.py
+++ b/app/models/determinazione.py
@@ -1,6 +1,8 @@
 from sqlalchemy import Column, String, DateTime, Float
 from app.database import Base
 import uuid
+
+
 class Determinazione(Base):
     __tablename__ = "determinazioni"
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -2,6 +2,8 @@ from sqlalchemy import Column, String, DateTime, Boolean, ForeignKey
 from sqlalchemy.orm import relationship
 from app.database import Base
 import uuid
+
+
 class Event(Base):
     __tablename__ = "events"
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))

--- a/app/models/pdf_file.py
+++ b/app/models/pdf_file.py
@@ -3,6 +3,7 @@ import uuid
 from sqlalchemy import Column, String, DateTime
 from app.database import Base
 
+
 class PDFFile(Base):
     __tablename__ = "pdf_files"
 

--- a/app/models/todo.py
+++ b/app/models/todo.py
@@ -2,6 +2,8 @@ from sqlalchemy import Column, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
 from app.database import Base
 import uuid
+
+
 class ToDo(Base):
     __tablename__ = "todos"
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
@@ -9,4 +11,3 @@ class ToDo(Base):
     scadenza = Column(DateTime, nullable=False)
     user_id = Column(String, ForeignKey("users.id"), nullable=False)
     user = relationship("User", back_populates="todos")
-

--- a/app/models/turno.py
+++ b/app/models/turno.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import relationship
 from app.database import Base
 import uuid
 
+
 class Turno(Base):
     __tablename__ = "turni"
 
@@ -21,4 +22,3 @@ class Turno(Base):
     note = Column(String, nullable=True)
 
     user = relationship("User", back_populates="turni")
-

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,6 +1,8 @@
 from sqlalchemy import Column, String
 from sqlalchemy.orm import relationship
 from app.database import Base
+
+
 class User(Base):
     __tablename__ = "users"
     id = Column(String, primary_key=True, index=True)
@@ -10,4 +12,3 @@ class User(Base):
     todos = relationship("ToDo", back_populates="user")
     events = relationship("Event", back_populates="user")
     turni = relationship("Turno", back_populates="user")
-

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -15,6 +15,7 @@ ALGORITHM = settings.ALGORITHM
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 router = APIRouter(tags=["Auth"])
 
+
 @router.post("/login")
 def login(form_data: UserCredentials, db: Session = Depends(get_db)):
     """Authenticate a user and issue a JWT access token.
@@ -24,9 +25,13 @@ def login(form_data: UserCredentials, db: Session = Depends(get_db)):
     400 HTTP error is raised.
     """
     db_user = user.get_user_by_email(db, form_data.email)
-    if not db_user or not user.verify_password(form_data.password, db_user.hashed_password):
+    if not db_user or not user.verify_password(
+        form_data.password, db_user.hashed_password
+    ):
         raise HTTPException(status_code=400, detail="Invalid credentials")
-    expire = datetime.datetime.utcnow() + datetime.timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    expire = datetime.datetime.utcnow() + datetime.timedelta(
+        minutes=ACCESS_TOKEN_EXPIRE_MINUTES
+    )
     payload = {"sub": db_user.email, "exp": int(expire.timestamp())}
     token = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
     return {"access_token": token, "token_type": "bearer"}

--- a/app/routes/determinazioni.py
+++ b/app/routes/determinazioni.py
@@ -6,10 +6,14 @@ from app.crud import determinazione
 
 router = APIRouter(prefix="/determinazioni", tags=["Determinazioni"])
 
+
 @router.post("/", response_model=DeterminazioneResponse)
-def create_determinazione_route(data: DeterminazioneCreate, db: Session = Depends(get_db)):
+def create_determinazione_route(
+    data: DeterminazioneCreate, db: Session = Depends(get_db)
+):
     """Create a new determinazione record and return it."""
     return determinazione.create_determinazione(db, data)
+
 
 @router.get("/", response_model=list[DeterminazioneResponse])
 def list_determinazioni(db: Session = Depends(get_db)):
@@ -17,8 +21,11 @@ def list_determinazioni(db: Session = Depends(get_db)):
     db_dets = determinazione.get_determinazioni(db)
     return db_dets
 
+
 @router.put("/{determinazione_id}", response_model=DeterminazioneResponse)
-def update_determinazione_route(determinazione_id: str, data: DeterminazioneCreate, db: Session = Depends(get_db)):
+def update_determinazione_route(
+    determinazione_id: str, data: DeterminazioneCreate, db: Session = Depends(get_db)
+):
     """Update an existing determinazione.
 
     Raises a 404 error if the record does not exist.
@@ -27,6 +34,7 @@ def update_determinazione_route(determinazione_id: str, data: DeterminazioneCrea
     if not db_det:
         raise HTTPException(status_code=404, detail="Determinazione not found")
     return db_det
+
 
 @router.delete("/{determinazione_id}")
 def delete_determinazione_route(determinazione_id: str, db: Session = Depends(get_db)):

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -4,7 +4,9 @@ from app.dependencies import get_db, get_current_user, get_optional_user
 from app.models.user import User
 from app.schemas.event import EventCreate, EventResponse
 from app.crud import event
+
 router = APIRouter(prefix="/events", tags=["Events"])
+
 
 @router.post("/", response_model=EventResponse, status_code=201)
 def create_event_route(
@@ -14,6 +16,8 @@ def create_event_route(
 ):
     """Create a new event and return the stored model."""
     return event.create_event(db, data, current_user)
+
+
 @router.get("/", response_model=list[EventResponse])
 def list_events(
     db: Session = Depends(get_db),
@@ -21,6 +25,8 @@ def list_events(
 ):
     """Retrieve all events from the database."""
     return event.get_events(db, current_user)
+
+
 @router.put("/{event_id}", response_model=EventResponse)
 def update_event_route(
     event_id: str,
@@ -33,6 +39,8 @@ def update_event_route(
     if not db_event:
         raise HTTPException(status_code=404, detail="Event not found")
     return db_event
+
+
 @router.delete("/{event_id}")
 def delete_event_route(
     event_id: str,

--- a/app/routes/todo.py
+++ b/app/routes/todo.py
@@ -7,6 +7,7 @@ from app.crud import todo
 
 router = APIRouter(prefix="/todo", tags=["ToDo"])
 
+
 @router.post("/", response_model=ToDoResponse)
 def create_todo_route(
     data: ToDoCreate,
@@ -16,12 +17,14 @@ def create_todo_route(
     """Create a todo item for the authenticated user."""
     return todo.create_todo(db, data, current_user)
 
+
 @router.get("/", response_model=list[ToDoResponse])
 def list_todos(
     db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
 ):
     """List todo items for the authenticated user."""
     return todo.get_todos(db, current_user)
+
 
 @router.put("/{todo_id}", response_model=ToDoResponse)
 def update_todo_route(
@@ -36,6 +39,7 @@ def update_todo_route(
         raise HTTPException(status_code=404, detail="ToDo not found")
     return db_todo
 
+
 @router.delete("/{todo_id}")
 def delete_todo_route(
     todo_id: str,
@@ -47,4 +51,3 @@ def delete_todo_route(
     if not db_todo:
         raise HTTPException(status_code=404, detail="ToDo not found")
     return {"ok": True}
-

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -4,7 +4,9 @@ from app.dependencies import get_db, get_current_user
 from app.schemas.user import UserCreate, UserResponse, UserOut
 from app.crud import user
 from app.models.user import User
+
 router = APIRouter(prefix="/users", tags=["Users"])
+
 
 # ───── nuovo endpoint GET /users/ ─────
 @router.get("/", response_model=list[UserResponse])
@@ -13,12 +15,16 @@ def list_users_route(
 ):
     """Restituisce la lista di tutti gli utenti."""
     return user.list_users(db)
+
+
 # ───────────────────────────────────────
+
 
 @router.post("/", response_model=UserResponse)
 def create_user_route(user_data: UserCreate, db: Session = Depends(get_db)):
     """Register a new user and return it."""
     return user.create_user(db, user_data.email, user_data.password, user_data.nome)
+
 
 # ───── nuovo endpoint GET /users/by-email ─────
 @router.get("/by-email", response_model=UserResponse)
@@ -28,6 +34,8 @@ def get_user_by_email_route(email: str, db: Session = Depends(get_db)):
     if not result:
         raise HTTPException(status_code=404, detail="User not found")
     return result
+
+
 # ───────────────────────────────────────────────
 
 
@@ -35,4 +43,6 @@ def get_user_by_email_route(email: str, db: Session = Depends(get_db)):
 def read_current_user(current_user: User = Depends(get_current_user)):
     """Restituisce i dati dell'utente autenticato (dal token JWT)."""
     return current_user
+
+
 # ───────────────────────────────────────────────

--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -42,7 +42,9 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
     elif "Agente" in df.columns:
         required = base_required | {"Agente"}
     else:
-        raise HTTPException(status_code=400, detail="Missing columns: {'User ID' or 'Agente'}")
+        raise HTTPException(
+            status_code=400, detail="Missing columns: {'User ID' or 'Agente'}"
+        )
 
     missing = required - set(df.columns)
     if missing:
@@ -82,14 +84,20 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
 
         payload: dict[str, Any] = {
             "user_id": user_id,
-            "giorno": row["Data"].date() if hasattr(row["Data"], "date") else row["Data"],
+            "giorno": (
+                row["Data"].date() if hasattr(row["Data"], "date") else row["Data"]
+            ),
             "inizio_1": row["Inizio1"],
             "fine_1": row["Fine1"],
             "tipo": row.get("Tipo", "NORMALE"),
             "note": row.get("Note", ""),
         }
 
-        if "Inizio2" in df.columns and not pd.isna(row.get("Inizio2")) and not pd.isna(row.get("Fine2")):
+        if (
+            "Inizio2" in df.columns
+            and not pd.isna(row.get("Inizio2"))
+            and not pd.isna(row.get("Fine2"))
+        ):
             payload["inizio_2"] = row["Inizio2"]
             payload["fine_2"] = row["Fine2"]
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -10,6 +10,7 @@ if config.config_file_name is not None:
 
 target_metadata = Base.metadata
 
+
 def run_migrations_offline() -> None:
     url = os.getenv("DATABASE_URL")
     context.configure(
@@ -21,6 +22,7 @@ def run_migrations_offline() -> None:
 
     with context.begin_transaction():
         context.run_migrations()
+
 
 def run_migrations_online() -> None:
     connectable = engine_from_config(
@@ -34,6 +36,7 @@ def run_migrations_online() -> None:
 
         with context.begin_transaction():
             context.run_migrations()
+
 
 if context.is_offline_mode():
     run_migrations_offline()

--- a/migrations/versions/0001_create_tables.py
+++ b/migrations/versions/0001_create_tables.py
@@ -3,72 +3,74 @@
 from alembic import op
 import sqlalchemy as sa
 
-revision = '0001_create_tables'
+revision = "0001_create_tables"
 down_revision = None
 branch_labels = None
 depends_on = None
 
+
 def upgrade() -> None:
     op.create_table(
-        'users',
-        sa.Column('id', sa.String(), primary_key=True),
-        sa.Column('email', sa.String(), nullable=False),
-        sa.Column('hashed_password', sa.String(), nullable=False),
-        sa.UniqueConstraint('email'),
+        "users",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("hashed_password", sa.String(), nullable=False),
+        sa.UniqueConstraint("email"),
     )
-    op.create_index('ix_users_id', 'users', ['id'])
-    op.create_index('ix_users_email', 'users', ['email'])
+    op.create_index("ix_users_id", "users", ["id"])
+    op.create_index("ix_users_email", "users", ["email"])
 
     op.create_table(
-        'events',
-        sa.Column('id', sa.String(), primary_key=True),
-        sa.Column('titolo', sa.String(), nullable=False),
-        sa.Column('descrizione', sa.String(), nullable=True),
-        sa.Column('data_ora', sa.DateTime(), nullable=False),
-        sa.Column('is_public', sa.Boolean(), nullable=True),
-        sa.Column('user_id', sa.String(), sa.ForeignKey('users.id'), nullable=False),
+        "events",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("titolo", sa.String(), nullable=False),
+        sa.Column("descrizione", sa.String(), nullable=True),
+        sa.Column("data_ora", sa.DateTime(), nullable=False),
+        sa.Column("is_public", sa.Boolean(), nullable=True),
+        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id"), nullable=False),
     )
-    op.create_index('ix_events_id', 'events', ['id'])
+    op.create_index("ix_events_id", "events", ["id"])
 
     op.create_table(
-        'pdf_files',
-        sa.Column('id', sa.Integer(), primary_key=True),
-        sa.Column('title', sa.String(), nullable=False),
-        sa.Column('filename', sa.String(), nullable=False),
-        sa.Column('uploaded_at', sa.DateTime(), nullable=True),
-        sa.UniqueConstraint('filename'),
+        "pdf_files",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("filename", sa.String(), nullable=False),
+        sa.Column("uploaded_at", sa.DateTime(), nullable=True),
+        sa.UniqueConstraint("filename"),
     )
-    op.create_index('ix_pdf_files_id', 'pdf_files', ['id'])
+    op.create_index("ix_pdf_files_id", "pdf_files", ["id"])
 
     op.create_table(
-        'determinazioni',
-        sa.Column('id', sa.String(), primary_key=True),
-        sa.Column('capitolo', sa.String(), nullable=False),
-        sa.Column('numero', sa.String(), nullable=False),
-        sa.Column('descrizione', sa.String(), nullable=False),
-        sa.Column('somma', sa.Float(), nullable=False),
-        sa.Column('scadenza', sa.DateTime(), nullable=False),
+        "determinazioni",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("capitolo", sa.String(), nullable=False),
+        sa.Column("numero", sa.String(), nullable=False),
+        sa.Column("descrizione", sa.String(), nullable=False),
+        sa.Column("somma", sa.Float(), nullable=False),
+        sa.Column("scadenza", sa.DateTime(), nullable=False),
     )
-    op.create_index('ix_determinazioni_id', 'determinazioni', ['id'])
+    op.create_index("ix_determinazioni_id", "determinazioni", ["id"])
 
     op.create_table(
-        'todos',
-        sa.Column('id', sa.String(), primary_key=True),
-        sa.Column('descrizione', sa.String(), nullable=False),
-        sa.Column('scadenza', sa.DateTime(), nullable=False),
-        sa.Column('user_id', sa.String(), sa.ForeignKey('users.id'), nullable=False),
+        "todos",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("descrizione", sa.String(), nullable=False),
+        sa.Column("scadenza", sa.DateTime(), nullable=False),
+        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id"), nullable=False),
     )
-    op.create_index('ix_todos_id', 'todos', ['id'])
+    op.create_index("ix_todos_id", "todos", ["id"])
+
 
 def downgrade() -> None:
-    op.drop_index('ix_todos_id', table_name='todos')
-    op.drop_table('todos')
-    op.drop_index('ix_determinazioni_id', table_name='determinazioni')
-    op.drop_table('determinazioni')
-    op.drop_index('ix_pdf_files_id', table_name='pdf_files')
-    op.drop_table('pdf_files')
-    op.drop_index('ix_events_id', table_name='events')
-    op.drop_table('events')
-    op.drop_index('ix_users_email', table_name='users')
-    op.drop_index('ix_users_id', table_name='users')
-    op.drop_table('users')
+    op.drop_index("ix_todos_id", table_name="todos")
+    op.drop_table("todos")
+    op.drop_index("ix_determinazioni_id", table_name="determinazioni")
+    op.drop_table("determinazioni")
+    op.drop_index("ix_pdf_files_id", table_name="pdf_files")
+    op.drop_table("pdf_files")
+    op.drop_index("ix_events_id", table_name="events")
+    op.drop_table("events")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_index("ix_users_id", table_name="users")
+    op.drop_table("users")

--- a/migrations/versions/0002_create_turni_table.py
+++ b/migrations/versions/0002_create_turni_table.py
@@ -3,30 +3,30 @@
 from alembic import op
 import sqlalchemy as sa
 
-revision = '0002_create_turni_table'
-down_revision = '0001_create_tables'
+revision = "0002_create_turni_table"
+down_revision = "0001_create_tables"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
     op.create_table(
-        'turni',
-        sa.Column('id', sa.String(), primary_key=True),
-        sa.Column('user_id', sa.String(), sa.ForeignKey('users.id'), nullable=False),
-        sa.Column('giorno', sa.Date(), nullable=False),
-        sa.Column('inizio_1', sa.Time(), nullable=False),
-        sa.Column('fine_1', sa.Time(), nullable=False),
-        sa.Column('inizio_2', sa.Time(), nullable=True),
-        sa.Column('fine_2', sa.Time(), nullable=True),
-        sa.Column('inizio_3', sa.Time(), nullable=True),
-        sa.Column('fine_3', sa.Time(), nullable=True),
-        sa.Column('tipo', sa.String(), nullable=True),
-        sa.Column('note', sa.String(), nullable=True),
+        "turni",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("giorno", sa.Date(), nullable=False),
+        sa.Column("inizio_1", sa.Time(), nullable=False),
+        sa.Column("fine_1", sa.Time(), nullable=False),
+        sa.Column("inizio_2", sa.Time(), nullable=True),
+        sa.Column("fine_2", sa.Time(), nullable=True),
+        sa.Column("inizio_3", sa.Time(), nullable=True),
+        sa.Column("fine_3", sa.Time(), nullable=True),
+        sa.Column("tipo", sa.String(), nullable=True),
+        sa.Column("note", sa.String(), nullable=True),
     )
-    op.create_index('ix_turni_id', 'turni', ['id'])
+    op.create_index("ix_turni_id", "turni", ["id"])
 
 
 def downgrade() -> None:
-    op.drop_index('ix_turni_id', table_name='turni')
-    op.drop_table('turni')
+    op.drop_index("ix_turni_id", table_name="turni")
+    op.drop_table("turni")

--- a/migrations/versions/0003_add_nome_to_user.py
+++ b/migrations/versions/0003_add_nome_to_user.py
@@ -3,14 +3,16 @@
 from alembic import op
 import sqlalchemy as sa
 
-revision = '0003_add_nome_to_user'
-down_revision = '0002_create_turni_table'
+revision = "0003_add_nome_to_user"
+down_revision = "0002_create_turni_table"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column('users', sa.Column('nome', sa.String(), nullable=False, server_default=''))
+    op.add_column(
+        "users", sa.Column("nome", sa.String(), nullable=False, server_default="")
+    )
     op.execute(
         """
         UPDATE users
@@ -25,4 +27,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column('users', 'nome')
+    op.drop_column("users", "nome")

--- a/migrations/versions/0004_pdf_file_uuid_id.py
+++ b/migrations/versions/0004_pdf_file_uuid_id.py
@@ -4,8 +4,8 @@ from alembic import op
 import sqlalchemy as sa
 import uuid
 
-revision = '0004_pdf_file_uuid_id'
-down_revision = '0003_add_nome_to_user'
+revision = "0004_pdf_file_uuid_id"
+down_revision = "0003_add_nome_to_user"
 branch_labels = None
 depends_on = None
 
@@ -13,41 +13,43 @@ depends_on = None
 def upgrade() -> None:
     conn = op.get_bind()
     # add temporary uuid column
-    with op.batch_alter_table('pdf_files') as batch_op:
-        batch_op.add_column(sa.Column('id_new', sa.String(), nullable=True))
+    with op.batch_alter_table("pdf_files") as batch_op:
+        batch_op.add_column(sa.Column("id_new", sa.String(), nullable=True))
 
     # populate with new uuids
-    results = conn.execute(sa.text('SELECT id FROM pdf_files')).fetchall()
+    results = conn.execute(sa.text("SELECT id FROM pdf_files")).fetchall()
     for row in results:
         conn.execute(
-            sa.text('UPDATE pdf_files SET id_new = :uuid WHERE id = :old_id'),
-            {'uuid': str(uuid.uuid4()), 'old_id': row[0]},
+            sa.text("UPDATE pdf_files SET id_new = :uuid WHERE id = :old_id"),
+            {"uuid": str(uuid.uuid4()), "old_id": row[0]},
         )
 
     # drop old id and rename new column
-    with op.batch_alter_table('pdf_files') as batch_op:
-        batch_op.drop_index('ix_pdf_files_id')
-        batch_op.drop_column('id')
-        batch_op.alter_column('id_new', new_column_name='id', nullable=False)
-        batch_op.create_index('ix_pdf_files_id', ['id'])
+    with op.batch_alter_table("pdf_files") as batch_op:
+        batch_op.drop_index("ix_pdf_files_id")
+        batch_op.drop_column("id")
+        batch_op.alter_column("id_new", new_column_name="id", nullable=False)
+        batch_op.create_index("ix_pdf_files_id", ["id"])
 
 
 def downgrade() -> None:
     conn = op.get_bind()
-    with op.batch_alter_table('pdf_files') as batch_op:
-        batch_op.drop_index('ix_pdf_files_id')
-        batch_op.add_column(sa.Column('id_old', sa.Integer(), autoincrement=True, nullable=True))
+    with op.batch_alter_table("pdf_files") as batch_op:
+        batch_op.drop_index("ix_pdf_files_id")
+        batch_op.add_column(
+            sa.Column("id_old", sa.Integer(), autoincrement=True, nullable=True)
+        )
 
-    results = conn.execute(sa.text('SELECT id FROM pdf_files')).fetchall()
+    results = conn.execute(sa.text("SELECT id FROM pdf_files")).fetchall()
     counter = 1
     for row in results:
         conn.execute(
-            sa.text('UPDATE pdf_files SET id_old = :new_id WHERE id = :uuid'),
-            {'new_id': counter, 'uuid': row[0]},
+            sa.text("UPDATE pdf_files SET id_old = :new_id WHERE id = :uuid"),
+            {"new_id": counter, "uuid": row[0]},
         )
         counter += 1
 
-    with op.batch_alter_table('pdf_files') as batch_op:
-        batch_op.drop_column('id')
-        batch_op.alter_column('id_old', new_column_name='id', nullable=False)
-        batch_op.create_index('ix_pdf_files_id', ['id'])
+    with op.batch_alter_table("pdf_files") as batch_op:
+        batch_op.drop_column("id")
+        batch_op.alter_column("id_old", new_column_name="id", nullable=False)
+        batch_op.create_index("ix_pdf_files_id", ["id"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
 from app.database import Base, engine
 from app import config
 
+
 @pytest.fixture(autouse=True)
 def setup_db():
     """Create a fresh database for each test."""
@@ -28,10 +29,12 @@ def setup_upload_dir(tmp_path):
 
     # Reload pdf_file module so it picks up the new setting
     import app.crud.pdf_file as pdf_file
+
     pdf_file = importlib.reload(pdf_file)
 
     # Update the reference used by the PDF routes
     import app.routes.pdf_files as pdf_routes
+
     pdf_routes.crud_pdf_file = pdf_file
 
     yield

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5,6 +5,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def auth_user(email: str):
     resp = client.post(
         "/users/", json={"email": email, "password": "secret", "nome": "Test"}
@@ -49,7 +50,10 @@ def test_dashboard_upcoming(monkeypatch, setup_db):
     )
     client.post(
         "/todo/",
-        json={"descrizione": "Other", "scadenza": (now + timedelta(days=1)).isoformat()},
+        json={
+            "descrizione": "Other",
+            "scadenza": (now + timedelta(days=1)).isoformat(),
+        },
         headers=other_h,
     )
 
@@ -72,4 +76,3 @@ def test_dashboard_upcoming(monkeypatch, setup_db):
     assert [item["kind"] for item in data] == ["event", "todo", "google"]
     times = [item["data_ora"] for item in data]
     assert times == sorted(times)
-

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,6 +2,7 @@ import importlib
 import pytest
 from app import config
 
+
 def test_sqlite_connect_args():
     original = config.settings.DATABASE_URL
     config.settings.DATABASE_URL = "sqlite:///./test.db"
@@ -29,4 +30,3 @@ def test_turno_invalid_user_fk(setup_db):
     with pytest.raises(IntegrityError):
         db.commit()
     db.close()
-

--- a/tests/test_determinazioni.py
+++ b/tests/test_determinazioni.py
@@ -5,6 +5,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_create_determinazione(setup_db):
     data = {
         "capitolo": "A",
@@ -24,12 +25,24 @@ def test_create_determinazione(setup_db):
 def test_update_determinazione(setup_db):
     res = client.post(
         "/determinazioni/",
-        json={"capitolo": "A", "numero": "1", "descrizione": "Old", "somma": 100.0, "scadenza": "2023-01-01T00:00:00"},
+        json={
+            "capitolo": "A",
+            "numero": "1",
+            "descrizione": "Old",
+            "somma": 100.0,
+            "scadenza": "2023-01-01T00:00:00",
+        },
     )
     det_id = res.json()["id"]
     response = client.put(
         f"/determinazioni/{det_id}",
-        json={"capitolo": "B", "numero": "1", "descrizione": "New", "somma": 200.0, "scadenza": "2023-02-01T00:00:00"},
+        json={
+            "capitolo": "B",
+            "numero": "1",
+            "descrizione": "New",
+            "somma": 200.0,
+            "scadenza": "2023-02-01T00:00:00",
+        },
     )
     assert response.status_code == 200
     data = response.json()
@@ -38,15 +51,42 @@ def test_update_determinazione(setup_db):
 
 
 def test_list_determinazioni(setup_db):
-    client.post("/determinazioni/", json={"capitolo": "A", "numero": "1", "descrizione": "", "somma": 50.0, "scadenza": "2023-01-01T00:00:00"})
-    client.post("/determinazioni/", json={"capitolo": "B", "numero": "2", "descrizione": "", "somma": 75.0, "scadenza": "2023-01-02T00:00:00"})
+    client.post(
+        "/determinazioni/",
+        json={
+            "capitolo": "A",
+            "numero": "1",
+            "descrizione": "",
+            "somma": 50.0,
+            "scadenza": "2023-01-01T00:00:00",
+        },
+    )
+    client.post(
+        "/determinazioni/",
+        json={
+            "capitolo": "B",
+            "numero": "2",
+            "descrizione": "",
+            "somma": 75.0,
+            "scadenza": "2023-01-02T00:00:00",
+        },
+    )
     response = client.get("/determinazioni/")
     assert response.status_code == 200
     assert len(response.json()) == 2
 
 
 def test_delete_determinazione(setup_db):
-    res = client.post("/determinazioni/", json={"capitolo": "A", "numero": "1", "descrizione": "", "somma": 50.0, "scadenza": "2023-01-01T00:00:00"})
+    res = client.post(
+        "/determinazioni/",
+        json={
+            "capitolo": "A",
+            "numero": "1",
+            "descrizione": "",
+            "somma": 50.0,
+            "scadenza": "2023-01-01T00:00:00",
+        },
+    )
     det_id = res.json()["id"]
     response = client.delete(f"/determinazioni/{det_id}")
     assert response.status_code == 200

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -10,8 +10,11 @@ def auth_user(email: str):
         "/users/", json={"email": email, "password": "secret", "nome": "Test"}
     )
     user_id = resp.json()["id"]
-    token = client.post("/login", json={"email": email, "password": "secret"}).json()["access_token"]
+    token = client.post("/login", json={"email": email, "password": "secret"}).json()[
+        "access_token"
+    ]
     return {"Authorization": f"Bearer {token}"}, user_id
+
 
 def test_create_event(setup_db):
     headers, user_id = auth_user("ev@example.com")
@@ -63,17 +66,32 @@ def test_list_events(setup_db):
     h2, _ = auth_user("b@example.com")
     client.post(
         "/events/",
-        json={"titolo": "A", "descrizione": "", "data_ora": "2023-01-01T09:00:00", "is_public": False},
+        json={
+            "titolo": "A",
+            "descrizione": "",
+            "data_ora": "2023-01-01T09:00:00",
+            "is_public": False,
+        },
         headers=h1,
     )
     client.post(
         "/events/",
-        json={"titolo": "B", "descrizione": "", "data_ora": "2023-01-02T09:00:00", "is_public": False},
+        json={
+            "titolo": "B",
+            "descrizione": "",
+            "data_ora": "2023-01-02T09:00:00",
+            "is_public": False,
+        },
         headers=h2,
     )
     client.post(
         "/events/",
-        json={"titolo": "Pub", "descrizione": "", "data_ora": "2023-01-03T09:00:00", "is_public": True},
+        json={
+            "titolo": "Pub",
+            "descrizione": "",
+            "data_ora": "2023-01-03T09:00:00",
+            "is_public": True,
+        },
         headers=h2,
     )
     res1 = client.get("/events/", headers=h1)
@@ -88,7 +106,12 @@ def test_delete_event(setup_db):
     headers, _ = auth_user("del@example.com")
     res = client.post(
         "/events/",
-        json={"titolo": "A", "descrizione": "", "data_ora": "2023-01-01T09:00:00", "is_public": False},
+        json={
+            "titolo": "A",
+            "descrizione": "",
+            "data_ora": "2023-01-01T09:00:00",
+            "is_public": False,
+        },
         headers=headers,
     )
     event_id = res.json()["id"]
@@ -96,4 +119,3 @@ def test_delete_event(setup_db):
     assert response.status_code == 200
     assert response.json()["ok"] is True
     assert client.get("/events/", headers=headers).json() == []
-

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -11,28 +11,30 @@ from app.services.excel_import import parse_excel, df_to_pdf
 
 
 def test_parse_excel(tmp_path):
-    df = pd.DataFrame([
-        {
-            "User ID": 1,
-            "Data": "2023-01-01",
-            "Inizio1": "08:00:00",
-            "Fine1": "12:00:00",
-            "Tipo": "NORMALE",
-            "Note": "n1",
-        },
-        {
-            "User ID": "2",
-            "Data": "2023-01-02",
-            "Inizio1": "09:00:00",
-            "Fine1": "13:00:00",
-            "Inizio2": "14:00:00",
-            "Fine2": "18:00:00",
-            "Inizio3": "19:00:00",
-            "Fine3": "21:00:00",
-            "Tipo": "EXTRA",
-            "Note": "n2",
-        },
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "User ID": 1,
+                "Data": "2023-01-01",
+                "Inizio1": "08:00:00",
+                "Fine1": "12:00:00",
+                "Tipo": "NORMALE",
+                "Note": "n1",
+            },
+            {
+                "User ID": "2",
+                "Data": "2023-01-02",
+                "Inizio1": "09:00:00",
+                "Fine1": "13:00:00",
+                "Inizio2": "14:00:00",
+                "Fine2": "18:00:00",
+                "Inizio3": "19:00:00",
+                "Fine3": "21:00:00",
+                "Tipo": "EXTRA",
+                "Note": "n2",
+            },
+        ]
+    )
     xls = tmp_path / "sample.xlsx"
     df.to_excel(xls, index=False)
 
@@ -63,16 +65,18 @@ def test_parse_excel(tmp_path):
 
 
 def test_parse_excel_straordinario(tmp_path):
-    df = pd.DataFrame([
-        {
-            "User ID": 3,
-            "Data": "2023-02-01",
-            "Inizio1": "08:00:00",
-            "Fine1": "12:00:00",
-            "Straordinario inizio": "20:00:00",
-            "Straordinario fine": "22:00:00",
-        }
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "User ID": 3,
+                "Data": "2023-02-01",
+                "Inizio1": "08:00:00",
+                "Fine1": "12:00:00",
+                "Straordinario inizio": "20:00:00",
+                "Straordinario fine": "22:00:00",
+            }
+        ]
+    )
     xls = tmp_path / "straordinario.xlsx"
     df.to_excel(xls, index=False)
 
@@ -102,14 +106,16 @@ def test_parse_excel_with_db(tmp_path):
     db.add(user)
     db.commit()
 
-    df = pd.DataFrame([
-        {
-            "Agente": "Agent X",
-            "Data": "2023-01-03",
-            "Inizio1": "07:00:00",
-            "Fine1": "11:00:00",
-        }
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "Agente": "Agent X",
+                "Data": "2023-01-03",
+                "Inizio1": "07:00:00",
+                "Fine1": "11:00:00",
+            }
+        ]
+    )
     xls = tmp_path / "agent.xlsx"
     df.to_excel(xls, index=False)
 
@@ -135,14 +141,16 @@ def test_parse_excel_missing_column(tmp_path):
 
     db = SessionLocal()
 
-    df = pd.DataFrame([
-        {
-            "Agente": "Agent X",
-            "Data": "2023-01-04",
-            "Inizio1": "07:00:00",
-            # "Fine1" column intentionally omitted
-        }
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "Agente": "Agent X",
+                "Data": "2023-01-04",
+                "Inizio1": "07:00:00",
+                # "Fine1" column intentionally omitted
+            }
+        ]
+    )
     xls = tmp_path / "missing.xlsx"
     df.to_excel(xls, index=False)
 
@@ -158,14 +166,16 @@ def test_parse_excel_missing_column(tmp_path):
 def test_parse_excel_agente_without_db(tmp_path):
     """Parsing fails when only the Agente column is present and no DB session is provided."""
 
-    df = pd.DataFrame([
-        {
-            "Agente": "Agent X",
-            "Data": "2023-01-05",
-            "Inizio1": "08:00:00",
-            "Fine1": "12:00:00",
-        }
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "Agente": "Agent X",
+                "Data": "2023-01-05",
+                "Inizio1": "08:00:00",
+                "Fine1": "12:00:00",
+            }
+        ]
+    )
     xls = tmp_path / "no_db.xlsx"
     df.to_excel(xls, index=False)
 
@@ -179,14 +189,16 @@ def test_parse_excel_agente_without_db(tmp_path):
 def test_parse_excel_empty_user_id(tmp_path):
     """Empty cells in the User ID column should result in a 400 error."""
 
-    df = pd.DataFrame([
-        {
-            "User ID": "",
-            "Data": "2023-03-01",
-            "Inizio1": "08:00:00",
-            "Fine1": "12:00:00",
-        }
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "User ID": "",
+                "Data": "2023-03-01",
+                "Inizio1": "08:00:00",
+                "Fine1": "12:00:00",
+            }
+        ]
+    )
     xls = tmp_path / "empty_user.xlsx"
     df.to_excel(xls, index=False)
 
@@ -202,14 +214,16 @@ def test_parse_excel_empty_agente(tmp_path):
     from app.database import SessionLocal
 
     db = SessionLocal()
-    df = pd.DataFrame([
-        {
-            "Agente": " ",
-            "Data": "2023-03-02",
-            "Inizio1": "08:00:00",
-            "Fine1": "12:00:00",
-        }
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "Agente": " ",
+                "Data": "2023-03-02",
+                "Inizio1": "08:00:00",
+                "Fine1": "12:00:00",
+            }
+        ]
+    )
     xls = tmp_path / "empty_agent.xlsx"
     df.to_excel(xls, index=False)
 
@@ -228,14 +242,16 @@ def test_parse_excel_unknown_user_id(tmp_path):
 
     db = SessionLocal()
 
-    df = pd.DataFrame([
-        {
-            "User ID": "missing",
-            "Data": "2023-04-01",
-            "Inizio1": "08:00:00",
-            "Fine1": "12:00:00",
-        }
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "User ID": "missing",
+                "Data": "2023-04-01",
+                "Inizio1": "08:00:00",
+                "Fine1": "12:00:00",
+            }
+        ]
+    )
     xls = tmp_path / "unknown_id.xlsx"
     df.to_excel(xls, index=False)
 
@@ -246,6 +262,7 @@ def test_parse_excel_unknown_user_id(tmp_path):
     assert exc.value.detail == "Row 2: Unknown user ID: missing"
 
     db.close()
+
 
 def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     rows = [
@@ -263,7 +280,9 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 
-    with patch("app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file):
+    with patch(
+        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
+    ):
         pdf_path, html_path = df_to_pdf(rows)
 
     assert os.path.exists(pdf_path)
@@ -292,7 +311,9 @@ def test_df_to_pdf_missing_wkhtmltopdf(tmp_path):
     def fake_from_file(html_path, pdf_path):
         raise OSError("No wkhtmltopdf executable found")
 
-    with patch("app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file):
+    with patch(
+        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
+    ):
         with pytest.raises(HTTPException) as exc:
             df_to_pdf(rows)
 

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -25,6 +25,7 @@ def test_iso_dt_uses_patched_timezone(monkeypatch):
             class DummyOffset:
                 def utcoffset(self, *args, **kwargs):
                     return timedelta(hours=9, minutes=30)
+
             return DummyOffset()
 
     class DummyDateTime:
@@ -59,7 +60,9 @@ def test_get_client_from_json_string(monkeypatch):
         fake_from_info,
     )
     monkeypatch.setattr(gcal, "build", lambda *a, **k: "CLIENT")
-    monkeypatch.setattr(gcal.settings, "GOOGLE_CREDENTIALS_JSON", json.dumps(dummy_info))
+    monkeypatch.setattr(
+        gcal.settings, "GOOGLE_CREDENTIALS_JSON", json.dumps(dummy_info)
+    )
 
     gcal.get_client.cache_clear()
     result = gcal.get_client()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -9,24 +9,31 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def auth_user(email: str, nome: str = "Mario Rossi"):
-    resp = client.post("/users/", json={"email": email, "password": "secret", "nome": nome})
+    resp = client.post(
+        "/users/", json={"email": email, "password": "secret", "nome": nome}
+    )
     body = resp.json()
     user_id = body["id"]
-    token = client.post("/login", json={"email": email, "password": "secret"}).json()["access_token"]
+    token = client.post("/login", json={"email": email, "password": "secret"}).json()[
+        "access_token"
+    ]
     return {"Authorization": f"Bearer {token}"}, user_id, nome
 
 
 def test_import_xlsx_creates_turni_and_returns_pdf(setup_db, tmp_path):
     headers, user_id, nome = auth_user("sheet@example.com")
-    df = pd.DataFrame([
-        {
-            "Agente": nome,
-            "Data": "2023-01-01",
-            "Inizio1": "08:00:00",
-            "Fine1": "12:00:00",
-        }
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "Agente": nome,
+                "Data": "2023-01-01",
+                "Inizio1": "08:00:00",
+                "Fine1": "12:00:00",
+            }
+        ]
+    )
     xlsx_path = tmp_path / "shift.xlsx"
     df.to_excel(xlsx_path, index=False)
 
@@ -34,11 +41,19 @@ def test_import_xlsx_creates_turni_and_returns_pdf(setup_db, tmp_path):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 
-    with patch("app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file):
+    with patch(
+        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
+    ):
         with open(xlsx_path, "rb") as fh:
             res = client.post(
                 "/import/xlsx",
-                files={"file": ("shift.xlsx", fh, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+                files={
+                    "file": (
+                        "shift.xlsx",
+                        fh,
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    )
+                },
             )
     assert res.status_code == 200
     assert res.headers["content-type"] == "application/pdf"
@@ -54,35 +69,43 @@ def test_temp_files_removed_after_request(setup_db, tmp_path):
     captured = {}
 
     def fake_parse_excel(path, db):
-        captured['xlsx'] = path
+        captured["xlsx"] = path
         return []
 
     def fake_from_file(html_path, pdf_path):
-        captured['html'] = html_path
-        captured['pdf'] = pdf_path
+        captured["html"] = html_path
+        captured["pdf"] = pdf_path
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 
     with patch("app.routes.imports.parse_excel", side_effect=fake_parse_excel):
-        with patch("app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file):
+        with patch(
+            "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
+        ):
             dummy = tmp_path / "shift.xlsx"
             dummy.write_bytes(b"data")
             with open(dummy, "rb") as fh:
                 res = client.post(
                     "/import/xlsx",
-                    files={"file": ("shift.xlsx", fh, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+                    files={
+                        "file": (
+                            "shift.xlsx",
+                            fh,
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        )
+                    },
                 )
     assert res.status_code == 200
-    assert not os.path.exists(captured['xlsx'])
-    assert not os.path.exists(captured['html'])
-    assert not os.path.exists(captured['pdf'])
+    assert not os.path.exists(captured["xlsx"])
+    assert not os.path.exists(captured["html"])
+    assert not os.path.exists(captured["pdf"])
 
 
 def test_parse_error_returns_400_and_removes_xlsx(tmp_path):
     captured = {}
 
     def fake_parse_excel(path, db):
-        captured['xlsx'] = path
+        captured["xlsx"] = path
         raise HTTPException(status_code=400, detail="bad data")
 
     with patch("app.routes.imports.parse_excel", side_effect=fake_parse_excel):
@@ -91,22 +114,30 @@ def test_parse_error_returns_400_and_removes_xlsx(tmp_path):
         with open(dummy, "rb") as fh:
             res = client.post(
                 "/import/xlsx",
-                files={"file": ("shift.xlsx", fh, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+                files={
+                    "file": (
+                        "shift.xlsx",
+                        fh,
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    )
+                },
             )
 
     assert res.status_code == 400
-    assert not os.path.exists(captured['xlsx'])
+    assert not os.path.exists(captured["xlsx"])
 
 
 def test_import_excel_alias_returns_pdf(tmp_path):
-    df = pd.DataFrame([
-        {
-            "Agente": "Mario Rossi",
-            "Data": "2023-01-01",
-            "Inizio1": "08:00:00",
-            "Fine1": "12:00:00",
-        }
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "Agente": "Mario Rossi",
+                "Data": "2023-01-01",
+                "Inizio1": "08:00:00",
+                "Fine1": "12:00:00",
+            }
+        ]
+    )
     xlsx_path = tmp_path / "shift.xlsx"
     df.to_excel(xlsx_path, index=False)
 
@@ -114,11 +145,19 @@ def test_import_excel_alias_returns_pdf(tmp_path):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 
-    with patch("app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file):
+    with patch(
+        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
+    ):
         with open(xlsx_path, "rb") as fh:
             res = client.post(
                 "/import/excel",
-                files={"file": ("shift.xlsx", fh, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+                files={
+                    "file": (
+                        "shift.xlsx",
+                        fh,
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    )
+                },
             )
 
     assert res.status_code == 200
@@ -127,21 +166,29 @@ def test_import_excel_alias_returns_pdf(tmp_path):
 
 def test_import_xlsx_unknown_agent_returns_400(tmp_path):
     """Uploading a sheet with an unknown Agente should return a 400 response."""
-    df = pd.DataFrame([
-        {
-            "Agente": "Unknown Agent",
-            "Data": "2023-01-01",
-            "Inizio1": "08:00:00",
-            "Fine1": "12:00:00",
-        }
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "Agente": "Unknown Agent",
+                "Data": "2023-01-01",
+                "Inizio1": "08:00:00",
+                "Fine1": "12:00:00",
+            }
+        ]
+    )
     xlsx_path = tmp_path / "unknown.xlsx"
     df.to_excel(xlsx_path, index=False)
 
     with open(xlsx_path, "rb") as fh:
         res = client.post(
             "/import/xlsx",
-            files={"file": ("unknown.xlsx", fh, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+            files={
+                "file": (
+                    "unknown.xlsx",
+                    fh,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
         )
 
     assert res.status_code == 400

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -8,9 +8,13 @@ client = TestClient(app)
 
 
 def auth_user(email: str, nome: str = "Test"):
-    resp = client.post("/users/", json={"email": email, "password": "secret", "nome": nome})
+    resp = client.post(
+        "/users/", json={"email": email, "password": "secret", "nome": nome}
+    )
     user_id = resp.json()["id"]
-    token = client.post("/login", json={"email": email, "password": "secret"}).json()["access_token"]
+    token = client.post("/login", json={"email": email, "password": "secret"}).json()[
+        "access_token"
+    ]
     return {"Authorization": f"Bearer {token}"}, user_id
 
 
@@ -59,7 +63,9 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
     client.post("/orari/", json=shift3, headers=headers)
 
     captured = {}
-    real_df_to_pdf = __import__("app.services.excel_import", fromlist=["df_to_pdf"]).df_to_pdf
+    real_df_to_pdf = __import__(
+        "app.services.excel_import", fromlist=["df_to_pdf"]
+    ).df_to_pdf
 
     def fake_from_file(html_path, pdf_path):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
@@ -69,7 +75,9 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
         captured["rows"] = rows
         return real_df_to_pdf(rows)
 
-    with patch("app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file):
+    with patch(
+        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
+    ):
         with patch("app.routes.orari.df_to_pdf", side_effect=capture_df_to_pdf):
             res = client.get("/orari/pdf?week=2023-W01", headers=headers)
 

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -7,6 +7,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_upload_pdf_and_list(setup_db, tmp_path):
     pdf_path = tmp_path / "sample.pdf"
     pdf_path.write_bytes(b"%PDF-1.4 test")
@@ -22,6 +23,7 @@ def test_upload_pdf_and_list(setup_db, tmp_path):
     assert "filename" in body
     # ensure id is a valid UUID string
     from uuid import UUID
+
     UUID(body["id"])
 
     list_res = client.get("/pdf/")

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -10,9 +10,9 @@ def auth_user(email: str):
         "/users/", json={"email": email, "password": "secret", "nome": "Test"}
     )
     user_id = resp.json()["id"]
-    token = client.post(
-        "/login", json={"email": email, "password": "secret"}
-    ).json()["access_token"]
+    token = client.post("/login", json={"email": email, "password": "secret"}).json()[
+        "access_token"
+    ]
     return {"Authorization": f"Bearer {token}"}, user_id
 
 
@@ -106,4 +106,3 @@ def test_user_isolated_todos(setup_db):
     assert len(res2.json()) == 1
     assert all(t["user_id"] == id1 for t in res1.json())
     assert all(t["user_id"] == id2 for t in res2.json())
-

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -5,14 +5,18 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def auth_user(email: str, nome: str = "Test"):
     resp = client.post(
         "/users/",
         json={"email": email, "password": "secret", "nome": nome},
     )
     user_id = resp.json()["id"]
-    token = client.post("/login", json={"email": email, "password": "secret"}).json()["access_token"]
+    token = client.post("/login", json={"email": email, "password": "secret"}).json()[
+        "access_token"
+    ]
     return {"Authorization": f"Bearer {token}"}, user_id
+
 
 def test_create_user():
     response = client.post(
@@ -25,6 +29,7 @@ def test_create_user():
     assert data["nome"] == "Test"
     assert "id" in data
     assert data["turni"] == []
+
 
 def test_duplicate_user():
     client.post(
@@ -54,7 +59,9 @@ def test_list_users():
 
 
 def test_user_turni_listed_after_creation(setup_db):
-    with patch("app.services.gcal.sync_shift_event"), patch("app.services.gcal.delete_shift_event"):
+    with patch("app.services.gcal.sync_shift_event"), patch(
+        "app.services.gcal.delete_shift_event"
+    ):
         headers, user_id = auth_user("shift@example.com")
 
         shift = {
@@ -111,4 +118,3 @@ def test_get_current_user_missing_header():
     response = client.get("/users/me")
     assert response.status_code == 401
     assert response.json()["detail"] == "Authorization header missing"
-


### PR DESCRIPTION
## Summary
- format all Python code under `app/`, `tests/`, and `migrations/` using black

## Testing
- `black app tests migrations`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686bc9c1ad308323b0ae2ff6901863b0