### PR TITLE
Add Google login endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ GOOGLE_CREDENTIALS_JSON=/path/to/service_account.json
 G_EVENT_CAL_ID=your_event_calendar@group.calendar.google.com      # calendario Eventi
 G_SHIFT_CAL_ID=your_shift_calendar@group.calendar.google.com      # calendario Turni
 
+# For Google sign-in token verification
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+
 GOOGLE_CALENDAR_ID=your_calendar_id
 CORS_ORIGINS=https://example.com    # comma separated origins
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 - `GOOGLE_CALENDAR_ID` – ID of the calendar to read events from.
 - `G_EVENT_CAL_ID` – ID of the Google Calendar used for event syncs.
 - `G_SHIFT_CAL_ID` – ID of the Google Calendar used for shift syncs.
+- `GOOGLE_CLIENT_ID` – OAuth client ID for verifying Google sign-in tokens.
 - `CORS_ORIGINS` – (optional) comma separated list of allowed origins for
   cross-origin requests. Defaults to `"*"`.
 - `LOG_LEVEL` – (optional) Python log level for application logging. Defaults
@@ -79,6 +80,19 @@ Example:
 curl -X POST http://localhost:8000/login \
   -H "Content-Type: application/json" \
   -d '{"email": "user@example.com", "password": "yourpassword"}'
+```
+
+### Google login
+
+When using Google Identity Services, send the ID token returned by the client
+to `/google-login`:
+
+```javascript
+fetch("http://localhost:8000/google-login", {
+  method: "POST",
+  headers: {"Content-Type": "application/json"},
+  body: JSON.stringify({token: googleToken}),
+});
 ```
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,7 @@ class Settings:
     G_EVENT_CAL_ID: str | None = None
     G_SHIFT_CAL_ID: str | None = None
     GOOGLE_CALENDAR_ID: str | None = None
+    GOOGLE_CLIENT_ID: str | None = None
     CORS_ORIGINS: str = "*"
     LOG_LEVEL: str = "INFO"
 
@@ -40,6 +41,7 @@ def load_settings() -> Settings:
         G_EVENT_CAL_ID=os.getenv("G_EVENT_CAL_ID"),
         G_SHIFT_CAL_ID=os.getenv("G_SHIFT_CAL_ID"),
         GOOGLE_CALENDAR_ID=os.getenv("GOOGLE_CALENDAR_ID"),
+        GOOGLE_CLIENT_ID=os.getenv("GOOGLE_CLIENT_ID"),
         CORS_ORIGINS=os.getenv("CORS_ORIGINS", "*"),
         LOG_LEVEL=os.getenv("LOG_LEVEL", "INFO"),
     )

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.dependencies import get_db
 from app.schemas.user import UserCreate, UserCredentials
+from pydantic import BaseModel
+from google.oauth2 import id_token
+from google.auth.transport import requests
 from app.crud import user
 from jose import jwt
 from app.config import settings
@@ -14,6 +17,10 @@ if not SECRET_KEY:
 ALGORITHM = settings.ALGORITHM
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 router = APIRouter(tags=["Auth"])
+
+
+class GoogleToken(BaseModel):
+    token: str
 
 
 @router.post("/login")
@@ -29,6 +36,34 @@ def login(form_data: UserCredentials, db: Session = Depends(get_db)):
         form_data.password, db_user.hashed_password
     ):
         raise HTTPException(status_code=400, detail="Invalid credentials")
+    expire = datetime.datetime.utcnow() + datetime.timedelta(
+        minutes=ACCESS_TOKEN_EXPIRE_MINUTES
+    )
+    payload = {"sub": db_user.email, "exp": int(expire.timestamp())}
+    token = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    return {"access_token": token, "token_type": "bearer"}
+
+
+@router.post("/google-login")
+def google_login(data: GoogleToken, db: Session = Depends(get_db)):
+    """Validate a Google ID token and issue a JWT access token."""
+    client_id = settings.GOOGLE_CLIENT_ID
+    if not client_id:
+        raise HTTPException(status_code=500, detail="GOOGLE_CLIENT_ID not configured")
+
+    try:
+        info = id_token.verify_oauth2_token(data.token, requests.Request(), client_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid Google token")
+
+    email = info.get("email")
+    if not email:
+        raise HTTPException(status_code=400, detail="Token missing email")
+
+    db_user = user.get_user_by_email(db, email)
+    if not db_user:
+        raise HTTPException(status_code=400, detail="User not found")
+
     expire = datetime.datetime.utcnow() + datetime.timedelta(
         minutes=ACCESS_TOKEN_EXPIRE_MINUTES
     )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,3 +2,4 @@ import os
 
 # Ensure a default secret key is available for tests
 os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,3 +27,47 @@ def test_login_invalid_credentials(setup_db):
         "/login", json={"email": "wrong@example.com", "password": "bad"}
     )
     assert response.status_code == 400
+
+
+def test_google_login_valid(monkeypatch, setup_db):
+    client.post(
+        "/users/",
+        json={"email": "google@example.com", "password": "secret", "nome": "G"},
+    )
+
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "gid")
+    from app import config
+
+    config.reload_settings()
+
+    def fake_verify(token, req, client_id):
+        assert token == "tok"
+        assert client_id == "gid"
+        return {"email": "google@example.com"}
+
+    monkeypatch.setattr(
+        "google.oauth2.id_token.verify_oauth2_token", fake_verify
+    )
+
+    res = client.post("/google-login", json={"token": "tok"})
+    assert res.status_code == 200
+    data = res.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+
+
+def test_google_login_invalid(monkeypatch):
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "gid")
+    from app import config
+
+    config.reload_settings()
+
+    def fake_verify(token, req, client_id):
+        raise ValueError("bad")
+
+    monkeypatch.setattr(
+        "google.oauth2.id_token.verify_oauth2_token", fake_verify
+    )
+
+    res = client.post("/google-login", json={"token": "bad"})
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- add GOOGLE_CLIENT_ID support in settings
- implement `/google-login` route
- show how to send GIS tokens in README
- document GOOGLE_CLIENT_ID in env and README
- test Google login behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686bedb61bf8832394ced51dd55b049b