### PR TITLE
Allow day-off shifts without times

### DIFF
--- a/app/models/turno.py
+++ b/app/models/turno.py
@@ -11,8 +11,8 @@ class Turno(Base):
     user_id = Column(String, ForeignKey("users.id"), nullable=False)
     giorno = Column(Date, nullable=False)
 
-    inizio_1 = Column(Time, nullable=False)
-    fine_1 = Column(Time, nullable=False)
+    inizio_1 = Column(Time, nullable=True)
+    fine_1 = Column(Time, nullable=True)
     inizio_2 = Column(Time, nullable=True)
     fine_2 = Column(Time, nullable=True)
     inizio_3 = Column(Time, nullable=True)

--- a/app/schemas/turno.py
+++ b/app/schemas/turno.py
@@ -1,19 +1,28 @@
 from datetime import date, time
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from typing import Optional
 from uuid import UUID
+
+DAY_OFF_TYPES = {"FERIE", "RIPOSO", "FESTIVO", "FERIE RIPOSO"}
 
 
 class TurnoBase(BaseModel):
     giorno: date
-    inizio_1: time
-    fine_1: time
+    inizio_1: Optional[time] = None
+    fine_1: Optional[time] = None
     inizio_2: Optional[time] = None
     fine_2: Optional[time] = None
     inizio_3: Optional[time] = None
     fine_3: Optional[time] = None
     tipo: str
     note: Optional[str] = None
+
+    @model_validator(mode="after")
+    def check_required_times(cls, data):
+        if (data.tipo or "").upper() not in DAY_OFF_TYPES:
+            if data.inizio_1 is None or data.fine_1 is None:
+                raise ValueError("inizio_1 and fine_1 are required")
+        return data
 
 
 class TurnoIn(TurnoBase):

--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -19,6 +19,8 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 import googleapiclient.errors as gerr
 
+from app.schemas.turno import DAY_OFF_TYPES
+
 
 # ------------------------------------------------------------------- credenziali
 @lru_cache()
@@ -76,6 +78,11 @@ def sync_shift_event(turno):
     Crea o aggiorna l'evento relativo a un turno
     nel calendario 'Turni di Servizio'.
     """
+    if (turno.tipo or "").upper() in DAY_OFF_TYPES:
+        # remove any existing calendar event for day-off records
+        delete_shift_event(turno.id)
+        return
+
     evt_id = f"shift-{turno.id}"  # chiave stabile = prefisso + UUID DB
 
     # orari: primo inizio disponibile, ultimo fine disponibile

--- a/migrations/versions/0005_optional_times_for_day_off.py
+++ b/migrations/versions/0005_optional_times_for_day_off.py
@@ -1,0 +1,21 @@
+"""make inizio_1 and fine_1 nullable"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0005_optional_times_for_day_off"
+down_revision = "0004_pdf_file_uuid_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("turni") as batch_op:
+        batch_op.alter_column("inizio_1", nullable=True)
+        batch_op.alter_column("fine_1", nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("turni") as batch_op:
+        batch_op.alter_column("inizio_1", nullable=False)
+        batch_op.alter_column("fine_1", nullable=False)

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -264,6 +264,35 @@ def test_parse_excel_unknown_user_id(tmp_path):
     db.close()
 
 
+def test_parse_excel_day_off_missing_times(tmp_path):
+    df = pd.DataFrame(
+        [
+            {
+                "User ID": 1,
+                "Data": "2024-01-01",
+                "Inizio1": None,
+                "Fine1": None,
+                "Tipo": "FESTIVO",
+            }
+        ]
+    )
+    xls = tmp_path / "dayoff.xlsx"
+    df.to_excel(xls, index=False)
+
+    rows = parse_excel(str(xls), None)
+
+    assert rows == [
+        {
+            "user_id": "1",
+            "giorno": "2024-01-01",
+            "inizio_1": None,
+            "fine_1": None,
+            "tipo": "FESTIVO",
+            "note": "",
+        }
+    ]
+
+
 def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     rows = [
         {


### PR DESCRIPTION
## Summary
- allow `inizio_1` and `fine_1` to be nullable in DB and model
- skip calendar sync for day-off shifts
- relax Excel parsing for `FESTIVO`/`FERIE`/`RIPOSO` types
- add alembic migration
- test creating day-off shifts and parsing Excel rows without times

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686beeb3d02c83239d4115a417ee6a9e