### PR TITLE
Add pool pre ping

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -15,7 +15,11 @@ else:
     connect_args = {"sslmode": "require"}
 
 # Crea il motore SQLAlchemy con gli argomenti appropriati
-engine = create_engine(DATABASE_URL, connect_args=connect_args)
+engine = create_engine(
+    DATABASE_URL,
+    connect_args=connect_args,
+    pool_pre_ping=True,
+)
 
 if url.drivername.startswith("sqlite"):
 


### PR DESCRIPTION
## Summary
- use `pool_pre_ping=True` when creating the SQLAlchemy engine

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686c042488688323b76d8fdb9175428a