### PR TITLE
Make database sslmode configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+DATABASE_SSLMODE=disable # optional, defaults to 'require'
 SECRET_KEY=your-secret-key
 ALGORITHM=HS256
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 ## Required environment variables
 
 - `DATABASE_URL` – connection string for the PostgreSQL database.
+- `DATABASE_SSLMODE` – (optional) sslmode used for PostgreSQL connections. If not specified and no `sslmode` parameter is present in `DATABASE_URL`, it defaults to `require`.
 - `SECRET_KEY` – secret key used to sign JWT tokens.
 - `ALGORITHM` – (optional) algorithm used for JWT; defaults to `HS256`.
 - `ACCESS_TOKEN_EXPIRE_MINUTES` – (optional) lifetime of access tokens in minutes; defaults to `30`.
@@ -39,6 +40,10 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
   cross-origin requests. Defaults to `"*"`.
 - `LOG_LEVEL` – (optional) Python log level for application logging. Defaults
   to `"INFO"`.
+
+When `DATABASE_SSLMODE` is unset and no `sslmode` parameter is included in
+`DATABASE_URL`, the application enforces secure connections by setting
+`sslmode=require`.
 
 ## Database migrations
 

--- a/app/database.py
+++ b/app/database.py
@@ -3,6 +3,7 @@ from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from app.config import settings
+import os
 
 # Recupera la URL del database dal modulo di configurazione
 DATABASE_URL = settings.DATABASE_URL
@@ -12,7 +13,13 @@ url = make_url(DATABASE_URL)
 if url.drivername.startswith("sqlite"):
     connect_args = {"check_same_thread": False}
 else:
-    connect_args = {"sslmode": "require"}
+    sslmode = os.getenv("DATABASE_SSLMODE")
+    if sslmode is not None:
+        connect_args = {"sslmode": sslmode}
+    elif "sslmode" in url.query:
+        connect_args = {}
+    else:
+        connect_args = {"sslmode": "require"}
 
 # Crea il motore SQLAlchemy con gli argomenti appropriati
 engine = create_engine(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -11,6 +11,32 @@ def test_sqlite_connect_args():
     assert db.CONNECT_ARGS == {"check_same_thread": False}
 
 
+def test_postgres_default_sslmode(monkeypatch):
+    original = config.settings.DATABASE_URL
+    config.settings.DATABASE_URL = "postgresql://user:pass@localhost/db"
+    db = importlib.reload(importlib.import_module("app.database"))
+    config.settings.DATABASE_URL = original
+    assert db.CONNECT_ARGS == {"sslmode": "require"}
+
+
+def test_postgres_url_has_sslmode(monkeypatch):
+    original = config.settings.DATABASE_URL
+    config.settings.DATABASE_URL = "postgresql://user:pass@localhost/db?sslmode=disable"
+    db = importlib.reload(importlib.import_module("app.database"))
+    config.settings.DATABASE_URL = original
+    assert db.CONNECT_ARGS == {}
+
+
+def test_postgres_env_override(monkeypatch):
+    original = config.settings.DATABASE_URL
+    config.settings.DATABASE_URL = "postgresql://user:pass@localhost/db"
+    monkeypatch.setenv("DATABASE_SSLMODE", "disable")
+    db = importlib.reload(importlib.import_module("app.database"))
+    monkeypatch.delenv("DATABASE_SSLMODE", raising=False)
+    config.settings.DATABASE_URL = original
+    assert db.CONNECT_ARGS == {"sslmode": "disable"}
+
+
 def test_turno_invalid_user_fk(setup_db):
     from datetime import date, time
     from sqlalchemy.exc import IntegrityError


### PR DESCRIPTION
## Summary
- allow overriding `sslmode` via `DATABASE_SSLMODE` or query parameter
- update env file example and README docs
- add tests for sslmode detection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686c11b9342083239463abc95f8fadf9