### PR TITLE
Add sslmode override check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
-DATABASE_SSLMODE=disable # optional, defaults to 'require'
+DATABASE_SSLMODE=disable # optional; overrides sslmode in DATABASE_URL and defaults to 'require'
 SECRET_KEY=your-secret-key
 ALGORITHM=HS256
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 ## Required environment variables
 
 - `DATABASE_URL` – connection string for the PostgreSQL database.
-- `DATABASE_SSLMODE` – (optional) sslmode used for PostgreSQL connections. If not specified and no `sslmode` parameter is present in `DATABASE_URL`, it defaults to `require`.
+- `DATABASE_SSLMODE` – (optional) sslmode used for PostgreSQL connections. When
+  set it overrides any `sslmode` parameter in `DATABASE_URL`. If neither is
+  provided, the application defaults to `require`.
 - `SECRET_KEY` – secret key used to sign JWT tokens.
 - `ALGORITHM` – (optional) algorithm used for JWT; defaults to `HS256`.
 - `ACCESS_TOKEN_EXPIRE_MINUTES` – (optional) lifetime of access tokens in minutes; defaults to `30`.
@@ -41,9 +43,9 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 - `LOG_LEVEL` – (optional) Python log level for application logging. Defaults
   to `"INFO"`.
 
-When `DATABASE_SSLMODE` is unset and no `sslmode` parameter is included in
-`DATABASE_URL`, the application enforces secure connections by setting
-`sslmode=require`.
+When `DATABASE_SSLMODE` is unset, the `sslmode` value from `DATABASE_URL` (if
+any) is honored. If neither specifies a value, the application enforces secure
+connections by setting `sslmode=require`.
 
 ## Database migrations
 

--- a/app/database.py
+++ b/app/database.py
@@ -13,10 +13,11 @@ url = make_url(DATABASE_URL)
 if url.drivername.startswith("sqlite"):
     connect_args = {"check_same_thread": False}
 else:
-    sslmode = os.getenv("DATABASE_SSLMODE")
-    if sslmode is not None:
-        connect_args = {"sslmode": sslmode}
-    elif "sslmode" in url.query:
+    sslmode_env = os.getenv("DATABASE_SSLMODE")
+    sslmode_query = url.query.get("sslmode")
+    if sslmode_env is not None:
+        connect_args = {"sslmode": sslmode_env}
+    elif sslmode_query is not None:
         connect_args = {}
     else:
         connect_args = {"sslmode": "require"}


### PR DESCRIPTION
## Summary
- check `sslmode` in `DATABASE_URL` before applying default
- clarify precedence of `DATABASE_SSLMODE` in documentation
- update environment example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686c2b8899908323b40ab2a8785a9174