### PR TITLE
Fix NaN handling in Excel import

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -23,7 +23,9 @@ def get_user_id(db: Session, agente: str) -> str:
 
 
 def _clean(cell: Any) -> Any:
-    """Strip whitespace from strings and convert empty values to ``None``."""
+    """Strip whitespace from strings and convert empty/NaN values to ``None``."""
+    if pd.isna(cell):
+        return None
     if isinstance(cell, str):
         cell = cell.strip()
         if cell == "":

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -322,6 +322,36 @@ def test_parse_excel_strips_whitespace(tmp_path):
     ]
 
 
+def test_parse_excel_day_off_nan_times(tmp_path):
+    """NaN time cells in day-off rows should be returned as None."""
+    df = pd.DataFrame(
+        [
+            {
+                "User ID": 5,
+                "Giorno": "2024-01-03",
+                "Inizio1": float("nan"),
+                "Fine1": float("nan"),
+                "Tipo": "FESTIVO",
+            }
+        ]
+    )
+    xls = tmp_path / "dayoff_nan.xlsx"
+    df.to_excel(xls, index=False)
+
+    rows = parse_excel(str(xls), None)
+
+    assert rows == [
+        {
+            "user_id": "5",
+            "giorno": "2024-01-03",
+            "inizio_1": None,
+            "fine_1": None,
+            "tipo": "FESTIVO",
+            "note": "",
+        }
+    ]
+
+
 def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     rows = [
         {


### PR DESCRIPTION
## Summary
- return `None` when Excel cells contain NaN values
- add regression test for NaN time columns on day-off rows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686c465a0ca48323b0d71abd983d6612