### PR TITLE
Add RECUPERO day off tests

### DIFF
--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -293,6 +293,36 @@ def test_parse_excel_day_off_missing_times(tmp_path):
     ]
 
 
+def test_parse_excel_day_off_missing_times_recupero(tmp_path):
+    """Day-off rows of type RECUPERO allow missing time values."""
+    df = pd.DataFrame(
+        [
+            {
+                "User ID": 2,
+                "Giorno": "2024-01-02",
+                "Inizio1": None,
+                "Fine1": None,
+                "Tipo": "RECUPERO",
+            }
+        ]
+    )
+    xls = tmp_path / "recupero.xlsx"
+    df.to_excel(xls, index=False)
+
+    rows = parse_excel(str(xls), None)
+
+    assert rows == [
+        {
+            "user_id": "2",
+            "giorno": "2024-01-02",
+            "inizio_1": None,
+            "fine_1": None,
+            "tipo": "RECUPERO",
+            "note": "",
+        }
+    ]
+
+
 def test_parse_excel_strips_whitespace(tmp_path):
     """Leading/trailing spaces in time columns are ignored."""
     df = pd.DataFrame(

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -175,3 +175,28 @@ def test_create_turno_day_off_allows_missing_times(setup_db):
     body = res.json()
     assert body["inizio_1"] is None
     assert body["fine_1"] is None
+
+
+def test_create_turno_recupero_skips_gcal_sync(setup_db):
+    """Creating a RECUPERO turno should not trigger calendar sync."""
+    headers, user_id = auth_user("recupero@example.com")
+    data = {
+        "user_id": user_id,
+        "giorno": "2023-12-26",
+        "inizio_1": None,
+        "fine_1": None,
+        "inizio_2": None,
+        "fine_2": None,
+        "inizio_3": None,
+        "fine_3": None,
+        "tipo": "RECUPERO",
+        "note": "",
+    }
+
+    with patch("app.services.gcal.sync_shift_event") as fake_sync:
+        res = client.post("/orari/", json=data, headers=headers)
+
+    assert res.status_code == 200
+    fake_sync.assert_not_called()
+    payload = res.json()
+    assert payload["tipo"] == "RECUPERO"


### PR DESCRIPTION
## Summary
- check RECUPERO day off rows when parsing Excel
- ensure RECUPERO day off creation does not sync calendar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686c48de1798832394e94ffa42c4ba6b