### PR TITLE
Update testing docs and provide helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,16 @@ fetch("http://localhost:8000/google-login", {
 
 ## Running tests
 
-Tests are located in the `tests/` directory. After installing the
-dependencies from both `requirements.txt` and `requirements-dev.txt`, make
-sure system packages such as `wkhtmltopdf` are available and export the
-environment variables required by the application (e.g. `DATABASE_URL`)
-before running the tests:
+Tests are located in the `tests/` directory. The suite requires all
+packages listed in both `requirements.txt` and `requirements-dev.txt`.
+System packages such as `wkhtmltopdf` must also be installed and the
+necessary environment variables (for example `DATABASE_URL`) exported.
+You can run the helper script `scripts/test.sh` which sets up a local
+virtual environment, installs these dependencies and executes `pytest`:
 
 ```bash
 export DATABASE_URL=postgresql://user:pass@localhost:5432/dbname
-pytest
+./scripts/test.sh
 ```
 
 The test suite uses a temporary SQLite database by default, but the

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VENV=".venv"
+
+if [ ! -d "$VENV" ]; then
+    echo "Creating virtual environment in $VENV"
+    python3 -m venv "$VENV"
+    echo "Installing dependencies"
+    "$VENV"/bin/pip install -r requirements.txt -r requirements-dev.txt
+fi
+
+. "$VENV"/bin/activate
+pytest "$@"
+


### PR DESCRIPTION
## Summary
- clarify that `requirements.txt` and `requirements-dev.txt` are both needed when running tests
- document new `scripts/test.sh` helper
- add helper shell script for new contributors

## Testing
- `./scripts/test.sh --maxfail=1 -k ""` *(fails: Could not find a version that satisfies the requirement fastapi==0.111.0)*

------
https://chatgpt.com/codex/tasks/task_e_686c48e100408323a7665d6af117c872