### PR TITLE
Normalize NaN in JSON payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000
 
 The API will be available at `http://localhost:8000/` by default.
 
+Incoming JSON payloads are parsed with a custom loader that converts any
+`NaN` values to `null` before Pydantic validation.
+
 ## Authentication
 
 Obtain a JWT access token using `POST /login`. The endpoint only accepts a

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import logging
+import json
 from app.config import settings
 from app.routes import (
     users,
@@ -20,7 +21,12 @@ from app.routes import imports
 log_level = settings.LOG_LEVEL.upper()
 logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
 
-app = FastAPI()
+
+def _loads_nan_as_none(data: str):
+    """Parse JSON treating ``NaN`` as ``None``."""
+    return json.loads(data, parse_constant=lambda _x: None)
+
+app = FastAPI(json_loads=_loads_nan_as_none)
 
 # Database tables are managed with Alembic migrations.
 # Tests create tables manually using `Base.metadata.create_all()`.

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -175,3 +175,27 @@ def test_create_turno_day_off_allows_missing_times(setup_db):
     body = res.json()
     assert body["inizio_1"] is None
     assert body["fine_1"] is None
+
+
+def test_create_turno_converts_nan_to_none(setup_db):
+    headers, user_id = auth_user("nan@example.com")
+    data = {
+        "user_id": user_id,
+        "giorno": "2023-07-01",
+        "inizio_1": "08:00:00",
+        "fine_1": "12:00:00",
+        "inizio_2": float("nan"),
+        "fine_2": float("nan"),
+        "inizio_3": float("nan"),
+        "fine_3": float("nan"),
+        "tipo": "NORMALE",
+        "note": "",
+    }
+
+    res = client.post("/orari/", json=data, headers=headers)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["inizio_2"] is None
+    assert body["fine_2"] is None
+    assert body["inizio_3"] is None
+    assert body["fine_3"] is None


### PR DESCRIPTION
## Summary
- normalize `NaN` to `null` when parsing JSON so validation succeeds
- mention NaN handling in the README
- test that shift creation accepts `NaN` values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686c469816388323a6cb45bfafe40152