### PR TITLE
Introduce TipoTurno enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ request under the `file` field. The same functionality is available via
 The Excel sheet **must** include the `Giorno`, `Inizio1` and `Fine1` columns and
 either a `User ID` or an `Agente` column. Optional columns are
 `Inizio2`/`Fine2`, `Inizio3`/`Fine3` (or `Straordinario inizio`/`Straordinario fine`), `Tipo` and `Note`.
+Valid values for `Tipo` are `NORMALE`, `STRAORD`, `FERIE`, `RIPOSO`, `FESTIVO` and `RECUPERO`.
 Rows marked as day off (with `Tipo` set to `FERIE`, `RIPOSO`, `FESTIVO` or `RECUPERO`) may leave the `Inizio1` and `Fine1` cells empty. The columns must still be present in the sheet.
 Leading and trailing spaces in time cells are ignored during parsing, but empty cells will raise a `400` error unless the row is a day off.
 

--- a/app/crud/turno.py
+++ b/app/crud/turno.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 from app.models.turno import Turno  # modello ORM
 from app.models.user import User
-from app.schemas.turno import TurnoIn  # Pydantic (input)
+from app.schemas.turno import TurnoIn, TipoTurno  # Pydantic (input)
 from app.services import gcal
 
 
@@ -49,7 +49,7 @@ def upsert_turno(db: Session, payload: TurnoIn) -> Turno:
     rec.inizio_3 = payload.inizio_3
     rec.fine_3 = payload.fine_3
 
-    rec.tipo = payload.tipo  # NORMALE | STRAORD | FERIE
+    rec.tipo = payload.tipo.value  # NORMALE | STRAORD | FERIE
     rec.note = payload.note
 
     # 4. salva su database

--- a/app/schemas/turno.py
+++ b/app/schemas/turno.py
@@ -1,9 +1,25 @@
 from datetime import date, time
-from pydantic import BaseModel, model_validator
+from enum import Enum
 from typing import Optional
 from uuid import UUID
 
-DAY_OFF_TYPES = {"FERIE", "RIPOSO", "FESTIVO", "RECUPERO"}
+from pydantic import BaseModel, model_validator
+
+class TipoTurno(str, Enum):
+    NORMALE = "NORMALE"
+    STRAORD = "STRAORD"
+    FERIE = "FERIE"
+    RIPOSO = "RIPOSO"
+    FESTIVO = "FESTIVO"
+    RECUPERO = "RECUPERO"
+
+
+DAY_OFF_TYPES = {
+    TipoTurno.FERIE,
+    TipoTurno.RIPOSO,
+    TipoTurno.FESTIVO,
+    TipoTurno.RECUPERO,
+}
 
 
 class TurnoBase(BaseModel):
@@ -14,12 +30,12 @@ class TurnoBase(BaseModel):
     fine_2: Optional[time] = None
     inizio_3: Optional[time] = None
     fine_3: Optional[time] = None
-    tipo: str
+    tipo: TipoTurno
     note: Optional[str] = None
 
     @model_validator(mode="after")
     def check_required_times(cls, data):
-        if (data.tipo or "").upper() not in DAY_OFF_TYPES:
+        if data.tipo not in DAY_OFF_TYPES:
             if data.inizio_1 is None or data.fine_1 is None:
                 raise ValueError("inizio_1 and fine_1 are required")
         return data

--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from fastapi import HTTPException
 
 from app.models.user import User
-from app.schemas.turno import DAY_OFF_TYPES
+from app.schemas.turno import DAY_OFF_TYPES, TipoTurno
 
 
 def get_user_id(db: Session, agente: str) -> str:
@@ -97,7 +97,9 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
         row_type = _clean(row.get("Tipo", "NORMALE")) or "NORMALE"
         inizio1 = _clean(row.get("Inizio1"))
         fine1 = _clean(row.get("Fine1"))
-        if (inizio1 is None or fine1 is None) and row_type.upper() not in DAY_OFF_TYPES:
+        if (
+            inizio1 is None or fine1 is None
+        ) and row_type.upper() not in {t.value for t in DAY_OFF_TYPES}:
             raise HTTPException(
                 status_code=400,
                 detail=f"Row {row_num}: Missing 'Inizio1' or 'Fine1'",

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.schemas.turno import TipoTurno
 
 client = TestClient(app)
 
@@ -30,7 +31,7 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
         "fine_2": None,
         "inizio_3": None,
         "fine_3": None,
-        "tipo": "NORMALE",
+        "tipo": TipoTurno.NORMALE.value,
         "note": "",
     }
     shift2 = {
@@ -42,7 +43,7 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
         "fine_2": None,
         "inizio_3": None,
         "fine_3": None,
-        "tipo": "NORMALE",
+        "tipo": TipoTurno.NORMALE.value,
         "note": "",
     }
     shift3 = {
@@ -54,7 +55,7 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
         "fine_2": None,
         "inizio_3": None,
         "fine_3": None,
-        "tipo": "NORMALE",
+        "tipo": TipoTurno.NORMALE.value,
         "note": "",
     }
 
@@ -111,7 +112,7 @@ def test_week_pdf_temp_files_removed(setup_db, tmp_path):
         "fine_2": None,
         "inizio_3": None,
         "fine_3": None,
-        "tipo": "NORMALE",
+        "tipo": TipoTurno.NORMALE.value,
         "note": "",
     }
 

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
+from app.schemas.turno import TipoTurno
 
 from app.main import app
 
@@ -29,7 +30,7 @@ def test_create_turno(setup_db):
         "fine_2": "17:00:00",
         "inizio_3": None,
         "fine_3": None,
-        "tipo": "NORMALE",
+        "tipo": TipoTurno.NORMALE.value,
         "note": "test",
     }
     res = client.post("/orari/", json=data, headers=headers)
@@ -56,14 +57,14 @@ def test_update_turno(setup_db):
         "fine_2": None,
         "inizio_3": None,
         "fine_3": None,
-        "tipo": "NORMALE",
+        "tipo": TipoTurno.NORMALE.value,
         "note": "",
     }
     first = client.post("/orari/", json=base, headers=headers)
     turno_id = first.json()["id"]
     base["inizio_1"] = "09:00:00"
     base["fine_1"] = "13:00:00"
-    base["tipo"] = "STRAORD"
+    base["tipo"] = TipoTurno.STRAORD.value
     update = client.post("/orari/", json=base, headers=headers)
     assert update.status_code == 200
     updated = update.json()
@@ -84,7 +85,7 @@ def test_delete_turno(setup_db):
         "fine_2": None,
         "inizio_3": None,
         "fine_3": None,
-        "tipo": "NORMALE",
+        "tipo": TipoTurno.NORMALE.value,
         "note": "",
     }
     res = client.post("/orari/", json=data, headers=headers)
@@ -123,7 +124,7 @@ def test_shift_event_summary_email(setup_db):
                 "fine_2": None,
                 "inizio_3": None,
                 "fine_3": None,
-                "tipo": "NORMALE",
+                "tipo": TipoTurno.NORMALE.value,
                 "note": "",
             },
             headers=headers,
@@ -144,7 +145,7 @@ def test_create_turno_unknown_user_returns_400(setup_db):
         "fine_2": None,
         "inizio_3": None,
         "fine_3": None,
-        "tipo": "NORMALE",
+        "tipo": TipoTurno.NORMALE.value,
         "note": "",
     }
 
@@ -164,7 +165,7 @@ def test_create_turno_day_off_allows_missing_times(setup_db):
         "fine_2": None,
         "inizio_3": None,
         "fine_3": None,
-        "tipo": "FESTIVO",
+        "tipo": TipoTurno.RECUPERO.value,
         "note": "",
     }
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 from fastapi.testclient import TestClient
+from app.schemas.turno import TipoTurno
 
 from app.main import app
 
@@ -73,7 +74,7 @@ def test_user_turni_listed_after_creation(setup_db):
             "fine_2": None,
             "inizio_3": None,
             "fine_3": None,
-            "tipo": "NORMALE",
+            "tipo": TipoTurno.NORMALE.value,
             "note": "",
         }
         res = client.post("/orari/", json=shift, headers=headers)


### PR DESCRIPTION
## Summary
- add `TipoTurno` enum and use it in `TurnoBase`
- handle enum values throughout CRUD and services
- adjust Excel import checks for day-off types
- update tests to use enum values and include `RECUPERO`
- document allowed `Tipo` values in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_686c48daaea8832382a453dd11a4d666