### PR TITLE
Handle NaN values when importing Excel shifts

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -47,6 +47,15 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
 
     df = pd.read_excel(path)  # requires openpyxl
 
+    import numpy as np
+
+    # Normalize NaN to None for time and note columns
+    time_cols = ["Inizio1", "Fine1", "Inizio2", "Fine2", "Inizio3", "Fine3"]
+    all_cols = time_cols + ["Note"]
+    for c in all_cols:
+        if c in df.columns:
+            df[c] = df[c].replace({np.nan: None})
+
     base_required = {"Giorno", "Inizio1", "Fine1"}
 
     if "User ID" in df.columns:


### PR DESCRIPTION
## Summary
- convert NaN to `None` for time columns and notes during Excel import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d52cb04d88323b1a17e418c2de631