### PR TITLE
Fix iso_dt to respect DST

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -53,7 +53,8 @@ SHIFT_CAL_ID = settings.G_SHIFT_CAL_ID  # nuovo calendario “Turni di Servizio�
 # ------------------------------------------------------------------- utilità
 def iso_dt(d: date, t: time) -> str:
     """2025-07-01 + 08:30 -> '2025-07-01T08:30:00+02:00'"""
-    offset = datetime.now().astimezone().utcoffset()
+    dt = datetime.combine(d, t)
+    offset = dt.astimezone().utcoffset()
     if offset is None:
         tz = "+00:00"
     else:

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -8,7 +8,7 @@ def test_iso_dt_current_offset():
     d = date(2023, 7, 1)
     t = time(8, 30)
     result = gcal.iso_dt(d, t)
-    offset = gcal.datetime.now().astimezone().utcoffset()
+    offset = gcal.datetime.combine(d, t).astimezone().utcoffset()
     if offset is None:
         expected = "+00:00"
     else:
@@ -20,7 +20,7 @@ def test_iso_dt_current_offset():
 
 
 def test_iso_dt_uses_patched_timezone(monkeypatch):
-    class DummyNow:
+    class DummyCombined:
         def astimezone(self):
             class DummyOffset:
                 def utcoffset(self, *args, **kwargs):
@@ -30,8 +30,8 @@ def test_iso_dt_uses_patched_timezone(monkeypatch):
 
     class DummyDateTime:
         @classmethod
-        def now(cls):
-            return DummyNow()
+        def combine(cls, d, t):
+            return DummyCombined()
 
     monkeypatch.setattr(gcal, "datetime", DummyDateTime)
 


### PR DESCRIPTION
## Summary
- fix UTC offset calculation in `iso_dt`
- update tests for DST-sensitive offset behavior

## Testing
- `pytest tests/test_gcal.py::test_iso_dt_current_offset -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d6847220c8323863cd6883a810fe8