### PR TITLE
Add G_SHIFT_CAL_ID check for calendar sync

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -78,6 +78,9 @@ def sync_shift_event(turno):
     Crea o aggiorna l'evento relativo a un turno
     nel calendario 'Turni di Servizio'.
     """
+    cal_id = settings.G_SHIFT_CAL_ID
+    if not cal_id:
+        raise RuntimeError("G_SHIFT_CAL_ID is not configured")
     try:
         tipo = TipoTurno(turno.tipo)
     except ValueError:
@@ -106,14 +109,14 @@ def sync_shift_event(turno):
     gcal = get_client()
     try:
         gcal.events().update(
-            calendarId=SHIFT_CAL_ID,
+            calendarId=cal_id,
             eventId=evt_id,
             body=body,
         ).execute()
     except gerr.HttpError as e:
         if e.resp.status == 404:  # evento non esiste → crealo
             gcal.events().insert(
-                calendarId=SHIFT_CAL_ID,
+                calendarId=cal_id,
                 body=body,
                 sendUpdates="none",
             ).execute()
@@ -126,10 +129,14 @@ def delete_shift_event(turno_id):
     Elimina dal calendario Turni l'evento legato al turno rimosso.
     Ignora l'errore 404 se l'evento era già assente.
     """
+    cal_id = settings.G_SHIFT_CAL_ID
+    if not cal_id:
+        raise RuntimeError("G_SHIFT_CAL_ID is not configured")
+
     gcal = get_client()
     try:
         gcal.events().delete(
-            calendarId=SHIFT_CAL_ID,
+            calendarId=cal_id,
             eventId=f"shift-{turno_id}",
         ).execute()
     except gerr.HttpError as e:

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date, time, timedelta
+import pytest
 
 from app.services import gcal
 
@@ -68,3 +69,15 @@ def test_get_client_from_json_string(monkeypatch):
     result = gcal.get_client()
     assert result == "CLIENT"
     assert captured["info"] == dummy_info
+
+
+def test_sync_shift_event_requires_calendar_id(monkeypatch):
+    monkeypatch.setattr(gcal.settings, "G_SHIFT_CAL_ID", None)
+    with pytest.raises(RuntimeError, match="G_SHIFT_CAL_ID is not configured"):
+        gcal.sync_shift_event(object())
+
+
+def test_delete_shift_event_requires_calendar_id(monkeypatch):
+    monkeypatch.setattr(gcal.settings, "G_SHIFT_CAL_ID", None)
+    with pytest.raises(RuntimeError, match="G_SHIFT_CAL_ID is not configured"):
+        gcal.delete_shift_event("dummy")


### PR DESCRIPTION
## Summary
- prevent shift calendar sync when `G_SHIFT_CAL_ID` is missing
- test missing calendar ID during sync functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d68480ee08323b81ce90a238a9a42