### PR TITLE
Handle invalid event IDs when syncing shifts

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -115,7 +115,9 @@ def sync_shift_event(turno):
             body=body,
         ).execute()
     except gerr.HttpError as e:
-        if e.resp.status == 404:  # evento non esiste → crealo
+        if e.resp.status in (404, 400):
+            # status 400 may be returned when Google thinks the event ID is invalid,
+            # so treat it like a missing event and create it from scratch
             gcal.events().insert(
                 calendarId=cal_id,
                 body=body,


### PR DESCRIPTION
## Summary
- treat Google Calendar 400 errors like 404 when syncing shift events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d719455088323880d255d841829ec