### PR TITLE
Pass DB session to df_to_pdf

### DIFF
--- a/app/routes/imports.py
+++ b/app/routes/imports.py
@@ -42,7 +42,7 @@ async def import_xlsx(
             crud_turno.upsert_turno(db, turno)
 
         # 4 – generate PDF summary
-        pdf_path, html_path = df_to_pdf(rows)
+        pdf_path, html_path = df_to_pdf(rows, db)
         background_tasks.add_task(os.remove, pdf_path)
         background_tasks.add_task(os.remove, html_path)
         return FileResponse(pdf_path, filename="turni_settimana.pdf")

--- a/app/routes/orari.py
+++ b/app/routes/orari.py
@@ -66,7 +66,7 @@ def week_pdf(
         for t in turni
     ]
 
-    pdf_path, html_path = df_to_pdf(rows)
+    pdf_path, html_path = df_to_pdf(rows, db)
     background_tasks.add_task(os.remove, pdf_path)
     background_tasks.add_task(os.remove, html_path)
     filename = f"turni_{week}.pdf"

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -401,7 +401,7 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     with patch(
         "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
     ):
-        pdf_path, html_path = df_to_pdf(rows)
+        pdf_path, html_path = df_to_pdf(rows, None)
 
     assert os.path.exists(pdf_path)
     assert os.path.exists(html_path)
@@ -433,7 +433,7 @@ def test_df_to_pdf_missing_wkhtmltopdf(tmp_path):
         "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
     ):
         with pytest.raises(HTTPException) as exc:
-            df_to_pdf(rows)
+            df_to_pdf(rows, None)
 
     assert exc.value.status_code == 500
     assert "wkhtmltopdf" in exc.value.detail

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -72,9 +72,9 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 
-    def capture_df_to_pdf(rows):
+    def capture_df_to_pdf(rows, db):
         captured["rows"] = rows
-        return real_df_to_pdf(rows)
+        return real_df_to_pdf(rows, db)
 
     with patch(
         "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
@@ -120,7 +120,7 @@ def test_week_pdf_temp_files_removed(setup_db, tmp_path):
 
     captured = {}
 
-    def fake_df_to_pdf(rows):
+    def fake_df_to_pdf(rows, db):
         pdf_path = tmp_path / "week.pdf"
         html_path = tmp_path / "week.html"
         pdf_path.write_bytes(b"%PDF-1.4 fake")


### PR DESCRIPTION
## Summary
- generate PDF tables with agent names when a DB session is provided
- call `df_to_pdf(rows, db)` from the imports and orari routes
- update tests for the new `df_to_pdf` signature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d8b9d127c832397ce1098a234c004