### PR TITLE
Update PDF generation tests

### DIFF
--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -401,7 +401,10 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     with patch(
         "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
     ):
-        pdf_path, html_path = df_to_pdf(rows)
+        pdf_path, html_path = df_to_pdf(rows, db=None)
+
+    html = Path(html_path).read_text()
+    assert "2023-01-01" in html
 
     assert os.path.exists(pdf_path)
     assert os.path.exists(html_path)
@@ -433,7 +436,7 @@ def test_df_to_pdf_missing_wkhtmltopdf(tmp_path):
         "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
     ):
         with pytest.raises(HTTPException) as exc:
-            df_to_pdf(rows)
+            df_to_pdf(rows, db=None)
 
     assert exc.value.status_code == 500
     assert "wkhtmltopdf" in exc.value.detail


### PR DESCRIPTION
## Summary
- account for new `db` arg when mocking `df_to_pdf`
- assert week header information is present in generated HTML
- capture and inspect HTML while still checking temporary file cleanup

## Testing
- `pytest tests/test_orari_pdf.py::test_week_pdf_filters_turni -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pytest tests/test_excel_import.py::test_df_to_pdf_creates_files_and_cleanup -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d8b9ee210832388da3c9b3564426c