### PR TITLE
Fix PDF tests import

### DIFF
--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from unittest.mock import patch
+import os
 from fastapi.testclient import TestClient
 
 from app.main import app


### PR DESCRIPTION
## Summary
- add missing `os` import in `test_orari_pdf`

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d8e757a0c8323bd5f6f7667e1a394