### PR TITLE
Add PDF HTML header assertions

### DIFF
--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -405,6 +405,8 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
 
     assert os.path.exists(pdf_path)
     assert os.path.exists(html_path)
+    html_text = Path(html_path).read_text()
+    assert "01/01/2023 – 01/01/2023" in html_text
 
     os.remove(pdf_path)
     os.remove(html_path)


### PR DESCRIPTION
## Summary
- verify generated HTML headers in PDF tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d9015f4b48323912114499b47fb63