### PR TITLE
Add logo header to PDF template

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -209,7 +209,10 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
             notes[day].append(str(row.get("note")))
 
     # Generate HTML
-    logo_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static", "Logo.png"))
+    logo_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "static", "Logo.png")
+    )
+    logo_uri = f"file://{logo_path}"
     styles = """
     <style>
     body { font-family: Aptos, sans-serif; font-size: 12pt; }
@@ -223,7 +226,7 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
 
     header = f"""
     <div style='text-align:center;'>
-        <img src='{logo_path}' alt='logo' /><br>
+        <img src='{logo_uri}' alt='logo' /><br>
         COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE<br>
         ORARIO DI SERVIZIO – {start_date} – {end_date}
     </div>

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -403,6 +403,11 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     ):
         pdf_path, html_path = df_to_pdf(rows, None)
 
+    with open(html_path) as fh:
+        content = fh.read()
+    assert "COMUNE DI CASTIONE DELLA PRESOLANA" in content
+    assert "ORARIO DI SERVIZIO" in content
+
     assert os.path.exists(pdf_path)
     assert os.path.exists(html_path)
 


### PR DESCRIPTION
## Summary
- embed logo path using `file://` scheme and add header check
- verify PDF HTML content in df_to_pdf test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d901bd65883239d14bb828231d84c