### PR TITLE
Add HTML header checks to PDF tests

### DIFF
--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -407,6 +407,11 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     assert os.path.exists(html_path)
     html_text = Path(html_path).read_text()
     assert "01/01/2023 – 01/01/2023" in html_text
+    assert "Logo.png" in html_text
+    assert (
+        "COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE"
+        in html_text
+    )
 
     os.remove(pdf_path)
     os.remove(html_path)

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -94,6 +94,11 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
     assert days == {"2023-01-02", "2023-01-08"}
     assert "02/01/2023 – 08/01/2023" in captured["html_text"]
     assert "<th>Test</th>" in captured["html_text"]
+    assert "Logo.png" in captured["html_text"]
+    assert (
+        "COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE"
+        in captured["html_text"]
+    )
 
 
 def test_week_pdf_invalid_format(setup_db):
@@ -150,5 +155,10 @@ def test_week_pdf_temp_files_removed(setup_db, tmp_path):
     assert res.status_code == 200
     assert "02/01/2023 – 08/01/2023" in captured["html_text"]
     assert "<th>Test</th>" in captured["html_text"]
+    assert "Logo.png" in captured["html_text"]
+    assert (
+        "COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE"
+        in captured["html_text"]
+    )
     assert not os.path.exists(captured["pdf"])
     assert not os.path.exists(captured["html"])


### PR DESCRIPTION
## Summary
- assert that generated PDFs embed the logo and service header

## Testing
- `./scripts/test.sh -q tests/test_excel_import.py::test_df_to_pdf_creates_files_and_cleanup tests/test_orari_pdf.py::test_week_pdf_filters_turni tests/test_orari_pdf.py::test_week_pdf_temp_files_removed` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d9203aef483238b35882de8160df5