### PR TITLE
Add ISO week header and weekday info in PDFs

### DIFF
--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -406,7 +406,8 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     assert os.path.exists(pdf_path)
     assert os.path.exists(html_path)
     html_text = Path(html_path).read_text()
-    assert "01/01/2023 – 01/01/2023" in html_text
+    assert "26/12/2022 – 01/01/2023" in html_text
+    assert "SUNDAY<br>01/01/2023" in html_text
     assert "Logo.png" in html_text
     assert (
         "COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE"

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -93,6 +93,8 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
     days = {r["giorno"] for r in captured["rows"]}
     assert days == {"2023-01-02", "2023-01-08"}
     assert "02/01/2023 – 08/01/2023" in captured["html_text"]
+    assert "MONDAY<br>02/01/2023" in captured["html_text"]
+    assert "SUNDAY<br>08/01/2023" in captured["html_text"]
     assert "<th>Test</th>" in captured["html_text"]
     assert "Logo.png" in captured["html_text"]
     assert (
@@ -154,6 +156,7 @@ def test_week_pdf_temp_files_removed(setup_db, tmp_path):
 
     assert res.status_code == 200
     assert "02/01/2023 – 08/01/2023" in captured["html_text"]
+    assert "MONDAY<br>02/01/2023" in captured["html_text"]
     assert "<th>Test</th>" in captured["html_text"]
     assert "Logo.png" in captured["html_text"]
     assert (


### PR DESCRIPTION
## Summary
- compute ISO week Monday and Sunday in `df_to_pdf`
- include weekday text in each PDF row
- update PDF tests to match new header and row format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d92c1f57c83239c2878ce4212c95e