### PR TITLE
Normalize Tipo value when parsing Excel

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -104,12 +104,12 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
             except ValueError as err:
                 raise HTTPException(status_code=400, detail=f"Row {row_num}: {err}")
 
-        row_type = _clean(row.get("Tipo", "NORMALE")) or "NORMALE"
+        row_type = (_clean(row.get("Tipo", "NORMALE")) or "NORMALE").upper()
         inizio1 = _clean(row.get("Inizio1"))
         fine1 = _clean(row.get("Fine1"))
-        if (
-            inizio1 is None or fine1 is None
-        ) and row_type.upper() not in {t.value for t in DAY_OFF_TYPES}:
+        if (inizio1 is None or fine1 is None) and row_type not in {
+            t.value for t in DAY_OFF_TYPES
+        }:
             raise HTTPException(
                 status_code=400,
                 detail=f"Row {row_num}: Missing 'Inizio1' or 'Fine1'",
@@ -118,7 +118,9 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
         payload: dict[str, Any] = {
             "user_id": user_id,
             "giorno": (
-                row["Giorno"].date() if hasattr(row["Giorno"], "date") else row["Giorno"]
+                row["Giorno"].date()
+                if hasattr(row["Giorno"], "date")
+                else row["Giorno"]
             ),
             "inizio_1": inizio1,
             "fine_1": fine1,
@@ -233,7 +235,11 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
     </div>
     """
 
-    table_header = "<tr><th>DATA</th>" + "".join(f"<th>{a}</th>" for a in agents) + "<th>ANNOTAZIONI DI SERVIZIO</th></tr>"
+    table_header = (
+        "<tr><th>DATA</th>"
+        + "".join(f"<th>{a}</th>" for a in agents)
+        + "<th>ANNOTAZIONI DI SERVIZIO</th></tr>"
+    )
 
     rows_html = []
     for day in sorted(by_date.keys()):

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -382,6 +382,51 @@ def test_parse_excel_day_off_nan_times(tmp_path):
     ]
 
 
+def test_parse_excel_mixed_case_tipo(tmp_path):
+    """Tipo values should be normalized to uppercase regardless of input case."""
+    df = pd.DataFrame(
+        [
+            {
+                "User ID": 6,
+                "Giorno": "2024-01-04",
+                "Inizio1": "08:00",
+                "Fine1": "12:00",
+                "Tipo": "normale",
+            },
+            {
+                "User ID": 7,
+                "Giorno": "2024-01-05",
+                "Inizio1": None,
+                "Fine1": None,
+                "Tipo": "Recupero",
+            },
+        ]
+    )
+    xls = tmp_path / "mixed.xlsx"
+    df.to_excel(xls, index=False)
+
+    rows = parse_excel(str(xls), None)
+
+    assert rows == [
+        {
+            "user_id": "6",
+            "giorno": "2024-01-04",
+            "inizio_1": "08:00",
+            "fine_1": "12:00",
+            "tipo": "NORMALE",
+            "note": "",
+        },
+        {
+            "user_id": "7",
+            "giorno": "2024-01-05",
+            "inizio_1": None,
+            "fine_1": None,
+            "tipo": "RECUPERO",
+            "note": "",
+        },
+    ]
+
+
 def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     rows = [
         {
@@ -409,8 +454,7 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     assert "01/01/2023 – 01/01/2023" in html_text
     assert "Logo.png" in html_text
     assert (
-        "COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE"
-        in html_text
+        "COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE" in html_text
     )
 
     os.remove(pdf_path)


### PR DESCRIPTION
## Summary
- ensure `Tipo` values are uppercased in `parse_excel`
- adjust check for missing time slots to use normalized `Tipo`
- test mixed-case `Tipo` values during Excel import

## Testing
- `black app/services/excel_import.py tests/test_excel_import.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d92c6622c832392bfea204e6cc88b