### PR TITLE
Handle case-insensitive Tipo in Excel import

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -106,12 +106,19 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
             except ValueError as err:
                 raise HTTPException(status_code=400, detail=f"Row {row_num}: {err}")
 
-        row_type = _clean(row.get("Tipo", "NORMALE")) or "NORMALE"
+        raw_tipo = _clean(row.get("Tipo")) or "NORMALE"
+        try:
+            row_type = TipoTurno(raw_tipo.strip().upper()).value
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Row {row_num}: Invalid 'Tipo' value: {raw_tipo}"
+            )
         inizio1 = _clean(row.get("Inizio1"))
         fine1 = _clean(row.get("Fine1"))
         if (
             inizio1 is None or fine1 is None
-        ) and row_type.upper() not in {t.value for t in DAY_OFF_TYPES}:
+        ) and row_type not in {t.value for t in DAY_OFF_TYPES}:
             raise HTTPException(
                 status_code=400,
                 detail=f"Row {row_num}: Missing 'Inizio1' or 'Fine1'",

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from fastapi import HTTPException
 from app.services.excel_import import parse_excel, df_to_pdf
+from app.schemas.turno import TipoTurno
 
 
 def test_parse_excel(tmp_path):
@@ -30,7 +31,7 @@ def test_parse_excel(tmp_path):
                 "Fine2": "18:00:00",
                 "Inizio3": "19:00:00",
                 "Fine3": "21:00:00",
-                "Tipo": "EXTRA",
+                "Tipo": TipoTurno.STRAORD.value,
                 "Note": "n2",
             },
         ]
@@ -58,7 +59,7 @@ def test_parse_excel(tmp_path):
             "fine_2": "18:00:00",
             "inizio_3": "19:00:00",
             "fine_3": "21:00:00",
-            "tipo": "EXTRA",
+            "tipo": TipoTurno.STRAORD.value,
             "note": "n2",
         },
     ]
@@ -318,6 +319,36 @@ def test_parse_excel_day_off_missing_times_recupero(tmp_path):
             "inizio_1": None,
             "fine_1": None,
             "tipo": "RECUPERO",
+            "note": "",
+        }
+    ]
+
+
+def test_parse_excel_lowercase_tipo(tmp_path):
+    """Tipo values are normalized to uppercase."""
+    df = pd.DataFrame(
+        [
+            {
+                "User ID": 10,
+                "Giorno": "2024-02-03",
+                "Inizio1": None,
+                "Fine1": None,
+                "Tipo": "ferie",
+            }
+        ]
+    )
+    xls = tmp_path / "lowercase.xlsx"
+    df.to_excel(xls, index=False)
+
+    rows = parse_excel(str(xls), None)
+
+    assert rows == [
+        {
+            "user_id": "10",
+            "giorno": "2024-02-03",
+            "inizio_1": None,
+            "fine_1": None,
+            "tipo": TipoTurno.FERIE.value,
             "note": "",
         }
     ]


### PR DESCRIPTION
## Summary
- normalize `Tipo` values in `parse_excel`
- update missing-times check to use the validated value
- update Excel import tests
- add a test for lowercase `Tipo`

## Testing
- `pytest -k excel_import -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686d95fb6c1c832388d246c074fef929