### PR TITLE
Add landscape orientation to PDF export

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -282,7 +282,7 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
 
     pdf_path = html_path.replace(".html", ".pdf")
     try:
-        pdfkit.from_file(html_path, pdf_path)
+        pdfkit.from_file(html_path, pdf_path, options={"orientation": "Landscape"})
     except OSError as err:
         if "wkhtmltopdf" in str(err):
             raise HTTPException(status_code=500, detail="wkhtmltopdf not installed")

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -425,7 +425,10 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
         }
     ]
 
-    def fake_from_file(html_path, pdf_path):
+    captured = {}
+
+    def fake_from_file(html_path, pdf_path, **kwargs):
+        captured["options"] = kwargs.get("options")
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 
@@ -436,6 +439,7 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
 
     assert os.path.exists(pdf_path)
     assert os.path.exists(html_path)
+    assert captured["options"] == {"orientation": "Landscape"}
     html_text = Path(html_path).read_text()
     assert "26/12/2022 – 01/01/2023" in html_text
     assert "SUNDAY<br>01/01/2023" in html_text
@@ -465,7 +469,7 @@ def test_df_to_pdf_missing_wkhtmltopdf(tmp_path):
         }
     ]
 
-    def fake_from_file(html_path, pdf_path):
+    def fake_from_file(html_path, pdf_path, **kwargs):
         raise OSError("No wkhtmltopdf executable found")
 
     with patch(
@@ -490,7 +494,7 @@ def test_df_to_pdf_missing_logo(monkeypatch):
         }
     ]
 
-    def fake_from_file(html_path, pdf_path):
+    def fake_from_file(html_path, pdf_path, **kwargs):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 
@@ -517,7 +521,7 @@ def test_df_to_pdf_escapes_html(tmp_path):
         }
     ]
 
-    def fake_from_file(html_path, pdf_path):
+    def fake_from_file(html_path, pdf_path, **kwargs):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -37,7 +37,7 @@ def test_import_xlsx_creates_turni_and_returns_pdf(setup_db, tmp_path):
     xlsx_path = tmp_path / "shift.xlsx"
     df.to_excel(xlsx_path, index=False)
 
-    def fake_from_file(html_path, pdf_path):
+    def fake_from_file(html_path, pdf_path, **kwargs):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 
@@ -72,7 +72,7 @@ def test_temp_files_removed_after_request(setup_db, tmp_path):
         captured["xlsx"] = path
         return []
 
-    def fake_from_file(html_path, pdf_path):
+    def fake_from_file(html_path, pdf_path, **kwargs):
         captured["html"] = html_path
         captured["pdf"] = pdf_path
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
@@ -141,7 +141,7 @@ def test_import_excel_alias_returns_pdf(tmp_path):
     xlsx_path = tmp_path / "shift.xlsx"
     df.to_excel(xlsx_path, index=False)
 
-    def fake_from_file(html_path, pdf_path):
+    def fake_from_file(html_path, pdf_path, **kwargs):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -69,7 +69,7 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
         "app.services.excel_import", fromlist=["df_to_pdf"]
     ).df_to_pdf
 
-    def fake_from_file(html_path, pdf_path):
+    def fake_from_file(html_path, pdf_path, **kwargs):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 
@@ -137,7 +137,7 @@ def test_week_pdf_temp_files_removed(setup_db, tmp_path):
         "app.services.excel_import", fromlist=["df_to_pdf"]
     ).df_to_pdf
 
-    def fake_from_file(html_path, pdf_path):
+    def fake_from_file(html_path, pdf_path, **kwargs):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 
@@ -190,7 +190,7 @@ def test_week_pdf_escapes_html(setup_db, tmp_path):
         "app.services.excel_import", fromlist=["df_to_pdf"]
     ).df_to_pdf
 
-    def fake_from_file(html_path, pdf_path):
+    def fake_from_file(html_path, pdf_path, **kwargs):
         Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
         return True
 


### PR DESCRIPTION
## Summary
- ensure df_to_pdf requests landscape orientation
- update tests to expect PDFKit 'orientation' option

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686da78385a883239d52e8688a1afc67