### PR TITLE
Use Italian weekday names

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -112,13 +112,13 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
         except ValueError:
             raise HTTPException(
                 status_code=400,
-                detail=f"Row {row_num}: Invalid 'Tipo' value: {raw_tipo}"
+                detail=f"Row {row_num}: Invalid 'Tipo' value: {raw_tipo}",
             )
         inizio1 = _clean(row.get("Inizio1"))
         fine1 = _clean(row.get("Fine1"))
-        if (
-            inizio1 is None or fine1 is None
-        ) and row_type not in {t.value for t in DAY_OFF_TYPES}:
+        if (inizio1 is None or fine1 is None) and row_type not in {
+            t.value for t in DAY_OFF_TYPES
+        }:
             raise HTTPException(
                 status_code=400,
                 detail=f"Row {row_num}: Missing 'Inizio1' or 'Fine1'",
@@ -127,7 +127,9 @@ def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
         payload: dict[str, Any] = {
             "user_id": user_id,
             "giorno": (
-                row["Giorno"].date() if hasattr(row["Giorno"], "date") else row["Giorno"]
+                row["Giorno"].date()
+                if hasattr(row["Giorno"], "date")
+                else row["Giorno"]
             ),
             "inizio_1": inizio1,
             "fine_1": fine1,
@@ -245,14 +247,26 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
     </div>
     """
 
-    table_header = "<tr><th>DATA</th>" + "".join(
-        f"<th>{html.escape(str(a))}</th>" for a in agents
-    ) + "<th>ANNOTAZIONI DI SERVIZIO</th></tr>"
+    table_header = (
+        "<tr><th>DATA</th>"
+        + "".join(f"<th>{html.escape(str(a))}</th>" for a in agents)
+        + "<th>ANNOTAZIONI DI SERVIZIO</th></tr>"
+    )
 
     rows_html = []
+    weekday_map = {
+        0: "LUNEDI",
+        1: "MARTEDI",
+        2: "MERCOLEDI",
+        3: "GIOVEDI",
+        4: "VENERDI",
+        5: "SABATO",
+        6: "DOMENICA",
+    }
+
     for day in sorted(by_date.keys()):
         date_obj = datetime.strptime(day, "%d/%m/%Y").date()
-        weekday = date_obj.strftime("%A").upper()
+        weekday = weekday_map[date_obj.weekday()]
         cells = [f"<td>{weekday}<br>{day}</td>"]
         for a in agents:
             cells.append(f"<td>{by_date[day].get(a, '')}</td>")

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -438,11 +438,10 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     assert os.path.exists(html_path)
     html_text = Path(html_path).read_text()
     assert "26/12/2022 – 01/01/2023" in html_text
-    assert "SUNDAY<br>01/01/2023" in html_text
+    assert "DOMENICA<br>01/01/2023" in html_text
     assert "Logo.png" in html_text
     assert (
-        "COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE"
-        in html_text
+        "COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE" in html_text
     )
 
     os.remove(pdf_path)

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -93,8 +93,8 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
     days = {r["giorno"] for r in captured["rows"]}
     assert days == {"2023-01-02", "2023-01-08"}
     assert "02/01/2023 – 08/01/2023" in captured["html_text"]
-    assert "MONDAY<br>02/01/2023" in captured["html_text"]
-    assert "SUNDAY<br>08/01/2023" in captured["html_text"]
+    assert "LUNEDI<br>02/01/2023" in captured["html_text"]
+    assert "DOMENICA<br>08/01/2023" in captured["html_text"]
     assert "<th>Test</th>" in captured["html_text"]
     assert "Logo.png" in captured["html_text"]
     assert (
@@ -156,7 +156,7 @@ def test_week_pdf_temp_files_removed(setup_db, tmp_path):
 
     assert res.status_code == 200
     assert "02/01/2023 – 08/01/2023" in captured["html_text"]
-    assert "MONDAY<br>02/01/2023" in captured["html_text"]
+    assert "LUNEDI<br>02/01/2023" in captured["html_text"]
     assert "<th>Test</th>" in captured["html_text"]
     assert "Logo.png" in captured["html_text"]
     assert (


### PR DESCRIPTION
## Summary
- map `date_obj.weekday()` to Italian day names in `df_to_pdf`
- adjust PDF tests for the new weekday output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_686da7ab36f883238920c627087fe2d1