### PR TITLE
Fix html variable conflict

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Tuple
 from sqlalchemy.orm import Session
 from fastapi import HTTPException
 import os
-import html
+import html as html_utils
 
 from app.models.user import User
 from app.schemas.turno import DAY_OFF_TYPES, TipoTurno
@@ -220,7 +220,7 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
         if agent:
             by_date[day][agent] = cell
         if row.get("note"):
-            notes[day].append(html.escape(str(row.get("note"))))
+            notes[day].append(html_utils.escape(str(row.get("note"))))
 
     # Generate HTML
     logo_path = os.path.abspath(
@@ -249,7 +249,7 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
 
     table_header = (
         "<tr><th>DATA</th>"
-        + "".join(f"<th>{html.escape(str(a))}</th>" for a in agents)
+        + "".join(f"<th>{html_utils.escape(str(a))}</th>" for a in agents)
         + "<th>ANNOTAZIONI DI SERVIZIO</th></tr>"
     )
 


### PR DESCRIPTION
## Summary
- rename html module import to `html_utils` to avoid naming conflicts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e1b10c6848323a2a57331d2caeb46