### PR TITLE
Add default shift calendar ID for tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,3 +3,4 @@ import os
 # Ensure a default secret key is available for tests
 os.environ.setdefault("SECRET_KEY", "test-secret-key")
 os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client")
+os.environ.setdefault("G_SHIFT_CAL_ID", "test-shift-cal")


### PR DESCRIPTION
## Summary
- set `G_SHIFT_CAL_ID` env var default in test suite

## Testing
- `./scripts/test.sh` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e1fcfe0808323ad7a999aa2e5b1f0