### PR TITLE
Fix RECUPERO sync

### DIFF
--- a/app/crud/turno.py
+++ b/app/crud/turno.py
@@ -57,12 +57,13 @@ def upsert_turno(db: Session, payload: TurnoIn) -> Turno:
     db.commit()
     db.refresh(rec)  # ottieni id definitivo
 
-    # 5. sincronizza l’evento Google Calendar
-    try:
-        gcal.sync_shift_event(rec)
-    except Exception as exc:
-        # non bloccare l’operazione DB se G-Cal fallisce, ma loggare
-        logger.error("Errore sync calendario: %s", exc)
+    # 5. sincronizza l’evento Google Calendar (salta per i RECUPERO)
+    if payload.tipo is not TipoTurno.RECUPERO:
+        try:
+            gcal.sync_shift_event(rec)
+        except Exception as exc:
+            # non bloccare l’operazione DB se G-Cal fallisce, ma loggare
+            logger.error("Errore sync calendario: %s", exc)
 
     return rec
 


### PR DESCRIPTION
## Summary
- don't sync calendar when creating RECUPERO turni

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `scripts/test.sh` *(fails to install dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686e1fd71d488323bc662d429b80cc2e