### PR TITLE
Remove unused event calendar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,6 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 PDF_UPLOAD_ROOT=uploads/pdfs
 GOOGLE_CREDENTIALS_JSON=/path/to/service_account.json
-G_EVENT_CAL_ID=your_event_calendar@group.calendar.google.com      # calendario Eventi
 G_SHIFT_CAL_ID=your_shift_calendar@group.calendar.google.com      # calendario Turni
 
 # For Google sign-in token verification

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 - `PDF_UPLOAD_ROOT` – directory where uploaded PDF files are stored.
 - `GOOGLE_CREDENTIALS_JSON` – JSON credentials (or path) for Google APIs.
 - `GOOGLE_CALENDAR_ID` – ID of the calendar to read events from.
-- `G_EVENT_CAL_ID` – ID of the Google Calendar used for event syncs.
 - `G_SHIFT_CAL_ID` – ID of the Google Calendar used for shift syncs.
 - `GOOGLE_CLIENT_ID` – OAuth client ID for verifying Google sign-in tokens.
 - `CORS_ORIGINS` – (optional) comma separated list of allowed origins for

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,6 @@ class Settings:
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     PDF_UPLOAD_ROOT: str = "uploads/pdfs"
     GOOGLE_CREDENTIALS_JSON: str | None = None
-    G_EVENT_CAL_ID: str | None = None
     G_SHIFT_CAL_ID: str | None = None
     GOOGLE_CALENDAR_ID: str | None = None
     GOOGLE_CLIENT_ID: str | None = None
@@ -38,7 +37,6 @@ def load_settings() -> Settings:
         ACCESS_TOKEN_EXPIRE_MINUTES=int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30")),
         PDF_UPLOAD_ROOT=os.getenv("PDF_UPLOAD_ROOT", "uploads/pdfs"),
         GOOGLE_CREDENTIALS_JSON=os.getenv("GOOGLE_CREDENTIALS_JSON"),
-        G_EVENT_CAL_ID=os.getenv("G_EVENT_CAL_ID"),
         G_SHIFT_CAL_ID=os.getenv("G_SHIFT_CAL_ID"),
         GOOGLE_CALENDAR_ID=os.getenv("GOOGLE_CALENDAR_ID"),
         GOOGLE_CLIENT_ID=os.getenv("GOOGLE_CLIENT_ID"),

--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -1,11 +1,8 @@
 # app/services/gcal.py
 """
-Helper unico per interagire con i due calendari Google:
-– calendario Eventi   (G_EVENT_CAL_ID)
-– calendario Turni    (G_SHIFT_CAL_ID)
+Helper unico per interagire con Google Calendar per i turni di servizio.
 Richiede:
   GOOGLE_CREDENTIALS_JSON=/percorso/service_account.json
-  G_EVENT_CAL_ID=…@group.calendar.google.com
   G_SHIFT_CAL_ID=…@group.calendar.google.com
 """
 
@@ -46,8 +43,7 @@ def get_client():
 
 
 # ------------------------------------------------------------------- calendar ID
-EVENT_CAL_ID = settings.G_EVENT_CAL_ID  # già in uso per gli altri eventi
-SHIFT_CAL_ID = settings.G_SHIFT_CAL_ID  # nuovo calendario “Turni di Servizio”
+SHIFT_CAL_ID = settings.G_SHIFT_CAL_ID  # calendario "Turni di Servizio"
 
 
 # ------------------------------------------------------------------- utilità


### PR DESCRIPTION
## Summary
- drop unused `G_EVENT_CAL_ID` configuration
- update example environment and README accordingly
- clean up calendar service docs

## Testing
- `./scripts/test.sh` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e341323d88323a5e894515d4f6ed5