### PR TITLE
Add Render deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ apt-get update && apt-get install -y wkhtmltopdf && pip install -r requirements.
 If deploying with Docker, the provided `Dockerfile` installs `wkhtmltopdf` prior
 to installing packages.
 
+A `render.yaml` file is also provided for deployments on **Render**. The web
+service uses Docker and runs on port `10000`, which Render expects the
+application to bind to.
+
 ### Troubleshooting CORS
 
 Set the `CORS_ORIGINS` environment variable to a comma-separated list of allowed

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,8 @@
+services:
+  - type: web
+    env: docker
+    dockerfilePath: Dockerfile
+    dockerCommand: uvicorn app.main:app --host 0.0.0.0 --port 10000
+    envVars:
+      - key: DATABASE_URL
+        sync: false


### PR DESCRIPTION
## Summary
- add `render.yaml` to configure a Render web service
- document Render deployment notes in README

## Testing
- `scripts/test.sh` *(fails: Could not install dependencies due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_686e5695652c83238a14568217b1cd03