### PR TITLE
Add Render deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,23 @@ apt-get update && apt-get install -y wkhtmltopdf && pip install -r requirements.
 If deploying with Docker, the provided `Dockerfile` installs `wkhtmltopdf` prior
 to installing packages.
 
+### Render
+
+Render can build the application directly from the included `Dockerfile`. A
+`render.yaml` file should be added at the repository root with a `web` service
+definition:
+
+```yaml
+services:
+  - type: web
+    env: docker
+    dockerfilePath: Dockerfile
+    dockerCommand: uvicorn app.main:app --host 0.0.0.0 --port 10000
+```
+
+The Dockerfile installs `wkhtmltopdf` automatically, so no additional system
+packages are needed during the build.
+
 ### Troubleshooting CORS
 
 Set the `CORS_ORIGINS` environment variable to a comma-separated list of allowed

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: segretaria-digitale
+    env: docker
+    dockerfilePath: Dockerfile
+    dockerCommand: uvicorn app.main:app --host 0.0.0.0 --port 10000
+


### PR DESCRIPTION
## Summary
- document deploying on Render
- add render.yaml for Render configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e56987e588323bd0ea9239d415470