### PR TITLE
Document Render deployment blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,15 @@ to installing packages.
 
 A `render.yaml` file is also provided for deployments on **Render**. The web
 service uses Docker and runs on port `10000`, which Render expects the
-application to bind to.
+application to bind to. Install the [Render CLI](https://render.com/docs/cli)
+and run
+
+```bash
+render blueprint deploy render.yaml
+```
+
+to create or update the service. Set the required environment variables
+(for example `DATABASE_URL` and `SECRET_KEY`) in the Render dashboard.
 
 ### Troubleshooting CORS
 


### PR DESCRIPTION
## Summary
- expand the README with instructions to deploy on Render using the CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e576bc80c8323bc4918c8ee4d8465