### PR TITLE
Switch to WeasyPrint for PDF generation

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -35,8 +35,8 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Install wkhtmltopdf
-      run: sudo apt-get update && sudo apt-get install -y wkhtmltopdf
+    - name: Install system packages
+      run: sudo apt-get update && sudo apt-get install -y libpango-1.0-0 libcairo2 gdk-pixbuf2.0-0 libffi-dev
 
     - name: Install dependencies
       run: pip install -r requirements.txt -r requirements-dev.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - name: Install system packages
+        run: sudo apt-get update && sudo apt-get install -y libpango-1.0-0 libcairo2 gdk-pixbuf2.0-0 libffi-dev
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.11-slim
 
 ENV PYTHONUNBUFFERED=1
 
-RUN apt-get update && apt-get install -y wkhtmltopdf \
+RUN apt-get update && apt-get install -y \
+    libpango-1.0-0 libcairo2 gdk-pixbuf2.0-0 libffi-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import pdfkit
+from weasyprint import HTML
 import tempfile
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Tuple
@@ -233,6 +233,7 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
         raise HTTPException(status_code=500, detail="Logo file missing")
     styles = """
     <style>
+    @page { size: A4 landscape; }
     body { font-family: Aptos, sans-serif; font-size: 12pt; }
     table { border-collapse: collapse; width: 100%; }
     th, td { border: 1px solid #000; padding: 4px; text-align: center; }
@@ -298,11 +299,6 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
         html_path = tmp_html.name
 
     pdf_path = html_path.replace(".html", ".pdf")
-    try:
-        pdfkit.from_file(html_path, pdf_path, options={"orientation": "Landscape"})
-    except OSError as err:
-        if "wkhtmltopdf" in str(err):
-            raise HTTPException(status_code=500, detail="wkhtmltopdf not installed")
-        raise
+    HTML(filename=html_path).write_pdf(pdf_path)
 
     return pdf_path, html_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ google-api-python-client==2.126.0
 google-auth==2.28.2
 pandas>=2.2.3
 openpyxl==3.1.2
-pdfkit==1.0.0
+WeasyPrint==61.0
 aiofiles==23.2.1

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -425,21 +425,14 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
         }
     ]
 
-    captured = {}
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        captured["options"] = kwargs.get("options")
-        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
-        return True
-
-    with patch(
-        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-    ):
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
         pdf_path, html_path = df_to_pdf(rows, None)
 
     assert os.path.exists(pdf_path)
     assert os.path.exists(html_path)
-    assert captured["options"] == {"orientation": "Landscape"}
     html_text = Path(html_path).read_text()
     assert "26/12/2022 – 01/01/2023" in html_text
     assert "DOMENICA<br>01/01/2023" in html_text
@@ -455,8 +448,8 @@ def test_df_to_pdf_creates_files_and_cleanup(tmp_path):
     assert not os.path.exists(html_path)
 
 
-def test_df_to_pdf_missing_wkhtmltopdf(tmp_path):
-    """An informative HTTPException is raised when wkhtmltopdf is missing."""
+def test_df_to_pdf_write_pdf_error(tmp_path):
+    """Errors from WeasyPrint propagate to the caller."""
     rows = [
         {
             "user_id": "1",
@@ -468,17 +461,12 @@ def test_df_to_pdf_missing_wkhtmltopdf(tmp_path):
         }
     ]
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        raise OSError("No wkhtmltopdf executable found")
+    def fake_write_pdf(self, target, *args, **kwargs):
+        raise OSError("boom")
 
-    with patch(
-        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-    ):
-        with pytest.raises(HTTPException) as exc:
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        with pytest.raises(OSError):
             df_to_pdf(rows, None)
-
-    assert exc.value.status_code == 500
-    assert "wkhtmltopdf" in exc.value.detail
 
 
 def test_df_to_pdf_missing_logo(monkeypatch):
@@ -493,13 +481,10 @@ def test_df_to_pdf_missing_logo(monkeypatch):
         }
     ]
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
-        return True
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
 
-    with patch(
-        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-    ):
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
         with patch("os.path.exists", return_value=False):
             with pytest.raises(HTTPException) as exc:
                 df_to_pdf(rows, None)
@@ -520,13 +505,10 @@ def test_df_to_pdf_escapes_html(tmp_path):
         }
     ]
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
-        return True
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
 
-    with patch(
-        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-    ):
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
         pdf_path, html_path = df_to_pdf(rows, None)
 
     html_text = Path(html_path).read_text()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -37,13 +37,10 @@ def test_import_xlsx_creates_turni_and_returns_pdf(setup_db, tmp_path):
     xlsx_path = tmp_path / "shift.xlsx"
     df.to_excel(xlsx_path, index=False)
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
-        return True
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
 
-    with patch(
-        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-    ):
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
         with open(xlsx_path, "rb") as fh:
             res = client.post(
                 "/import/xlsx",
@@ -72,16 +69,13 @@ def test_temp_files_removed_after_request(setup_db, tmp_path):
         captured["xlsx"] = path
         return []
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        captured["html"] = html_path
-        captured["pdf"] = pdf_path
-        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
-        return True
+    def fake_write_pdf(self, target, *args, **kwargs):
+        captured["html"] = target
+        captured["pdf"] = target
+        Path(target).write_bytes(b"%PDF-1.4 fake")
 
     with patch("app.routes.imports.parse_excel", side_effect=fake_parse_excel):
-        with patch(
-            "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-        ):
+        with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
             dummy = tmp_path / "shift.xlsx"
             dummy.write_bytes(b"data")
             with open(dummy, "rb") as fh:
@@ -141,13 +135,10 @@ def test_import_excel_alias_returns_pdf(tmp_path):
     xlsx_path = tmp_path / "shift.xlsx"
     df.to_excel(xlsx_path, index=False)
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
-        return True
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
 
-    with patch(
-        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-    ):
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
         with open(xlsx_path, "rb") as fh:
             res = client.post(
                 "/import/excel",
@@ -272,13 +263,10 @@ def test_import_xlsx_data_column_alias(setup_db, tmp_path):
     xlsx_path = tmp_path / "data_alias.xlsx"
     df.to_excel(xlsx_path, index=False)
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
-        return True
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
 
-    with patch(
-        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-    ):
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
         with open(xlsx_path, "rb") as fh:
             res = client.post(
                 "/import/xlsx",

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -69,9 +69,8 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
         "app.services.excel_import", fromlist=["df_to_pdf"]
     ).df_to_pdf
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
-        return True
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
 
     def capture_df_to_pdf(rows, db):
         captured["rows"] = rows
@@ -81,9 +80,7 @@ def test_week_pdf_filters_turni(setup_db, tmp_path):
         captured["html_text"] = Path(html_path).read_text()
         return pdf_path, html_path
 
-    with patch(
-        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-    ):
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
         with patch("app.routes.orari.df_to_pdf", side_effect=capture_df_to_pdf):
             res = client.get("/orari/pdf?week=2023-W01", headers=headers)
 
@@ -137,9 +134,8 @@ def test_week_pdf_temp_files_removed(setup_db, tmp_path):
         "app.services.excel_import", fromlist=["df_to_pdf"]
     ).df_to_pdf
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
-        return True
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
 
     def capture_df_to_pdf(rows, db):
         pdf_path, html_path = real_df_to_pdf(rows, db)
@@ -148,9 +144,7 @@ def test_week_pdf_temp_files_removed(setup_db, tmp_path):
         captured["html_text"] = Path(html_path).read_text()
         return pdf_path, html_path
 
-    with patch(
-        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-    ):
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
         with patch("app.routes.orari.df_to_pdf", side_effect=capture_df_to_pdf):
             res = client.get("/orari/pdf?week=2023-W01", headers=headers)
 
@@ -190,18 +184,15 @@ def test_week_pdf_escapes_html(setup_db, tmp_path):
         "app.services.excel_import", fromlist=["df_to_pdf"]
     ).df_to_pdf
 
-    def fake_from_file(html_path, pdf_path, **kwargs):
-        Path(pdf_path).write_bytes(b"%PDF-1.4 fake")
-        return True
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
 
     def capture_df_to_pdf(rows, db):
         pdf_path, html_path = real_df_to_pdf(rows, db)
         captured["html_text"] = Path(html_path).read_text()
         return pdf_path, html_path
 
-    with patch(
-        "app.services.excel_import.pdfkit.from_file", side_effect=fake_from_file
-    ):
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
         with patch("app.routes.orari.df_to_pdf", side_effect=capture_df_to_pdf):
             res = client.get("/orari/pdf?week=2023-W01", headers=headers)
 


### PR DESCRIPTION
## Summary
- replace pdfkit with WeasyPrint in requirements
- render PDFs using WeasyPrint in `df_to_pdf`
- install WeasyPrint system packages in Dockerfile and CI
- update tests to mock WeasyPrint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e627ae6f8832381663a417831c98a