### PR TITLE
Update WeasyPrint and add pydyf

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a FastAPI backend used by Segretaria Digitale.
 
 1. Ensure you have **Python 3.10–3.11** installed.
 2. Create a virtual environment and install dependencies (including `httpx`,
-   `pandas`, `openpyxl` and `WeasyPrint`):
+   `pandas`, `openpyxl`, `WeasyPrint==60.1` and `pydyf==0.8.0`):
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ google-api-python-client==2.126.0
 google-auth==2.28.2
 pandas>=2.2.3
 openpyxl==3.1.2
-WeasyPrint==61.0
+WeasyPrint==60.1
+pydyf==0.8.0
 aiofiles==23.2.1


### PR DESCRIPTION
## Summary
- pin WeasyPrint to 60.1 and add pydyf requirement
- mention new versions in Setup section of README

## Testing
- `./scripts/test.sh` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_686e68d34cbc83239056d0ed486cb2d5