### PR TITLE
Include start time in Google Calendar event titles

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -99,9 +99,10 @@ def sync_shift_event(turno):
     start = first_non_null(turno.inizio_1, turno.inizio_2, turno.inizio_3)
     end = last_non_null(turno.fine_3, turno.fine_2, turno.fine_1)
 
+    title_name = turno.user.nome or turno.user.email.split("@")[0]
     body = {
         "id": evt_id,
-        "summary": turno.user.nome or turno.user.email.split("@")[0],
+        "summary": f"{start.strftime('%H:%M')} {title_name}",
         "description": turno.note or "",
         "start": {"dateTime": iso_dt(turno.giorno, start)},
         "end": {"dateTime": iso_dt(turno.giorno, end)},

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -130,7 +130,7 @@ def test_shift_event_summary_email(setup_db):
             headers=headers,
         )
 
-    assert captured["body"]["summary"] == "Calendar User"
+    assert captured["body"]["summary"] == "08:00 Calendar User"
 
 
 def test_create_turno_unknown_user_returns_400(setup_db):


### PR DESCRIPTION
## Summary
- prefix Google Calendar event titles with the shift start time
- update shift event summary test

## Testing
- `pip install -q -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e6f94c2788323a4e5c40d975cd677