### PR TITLE
Remove seconds from shift PDF times

### DIFF
--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -519,3 +519,30 @@ def test_df_to_pdf_escapes_html(tmp_path):
 
     os.remove(pdf_path)
     os.remove(html_path)
+
+
+def test_df_to_pdf_formats_times_without_seconds(tmp_path):
+    rows = [
+        {
+            "Agente": "Agent",
+            "giorno": "2023-01-01",
+            "inizio_1": "08:00:00",
+            "fine_1": "12:00:00",
+            "tipo": "NORMALE",
+            "note": "",
+        }
+    ]
+
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
+
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        pdf_path, html_path = df_to_pdf(rows, None)
+
+    html_text = Path(html_path).read_text()
+    assert "08:00 – 12:00" in html_text
+    assert "08:00:00" not in html_text
+    assert "12:00:00" not in html_text
+
+    os.remove(pdf_path)
+    os.remove(html_path)


### PR DESCRIPTION
## Summary
- ensure shift times in PDFs show hours and minutes only
- cover new time formatting with unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e715d115c8323a8937740d71eb460