### PR TITLE
Fix NaN segments in PDF generation

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -36,6 +36,14 @@ def _clean(cell: Any) -> Any:
     return cell
 
 
+def _not_nan(value: Any) -> bool:
+    """Return ``False`` when ``value`` is ``None`` or NaN."""
+
+    if value is None:
+        return False
+    return not pd.isna(value)
+
+
 def parse_excel(path: str, db: Session | None = None) -> List[Dict[str, Any]]:
     """Parse an Excel file exported from Google Sheets.
 
@@ -227,9 +235,9 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
             segments: list[str] = []
             if row.get("inizio_1") and row.get("fine_1"):
                 segments.append(f"{fmt(row['inizio_1'])} – {fmt(row['fine_1'])}")
-            if row.get("inizio_2") and row.get("fine_2"):
+            if _not_nan(row.get("inizio_2")) and _not_nan(row.get("fine_2")):
                 segments.append(f"{fmt(row['inizio_2'])} – {fmt(row['fine_2'])}")
-            if row.get("inizio_3") and row.get("fine_3"):
+            if _not_nan(row.get("inizio_3")) and _not_nan(row.get("fine_3")):
                 segments.append(
                     f"<span class='extra'>{fmt(row['inizio_3'])} – {fmt(row['fine_3'])} STRAORDINARIO</span>"
                 )

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -546,3 +546,55 @@ def test_df_to_pdf_formats_times_without_seconds(tmp_path):
 
     os.remove(pdf_path)
     os.remove(html_path)
+
+
+def fake_write_pdf(self, target, *args, **kwargs):
+    Path(target).write_bytes(b"%PDF-1.4 fake")
+
+
+def test_df_to_pdf_skips_nan_second_segment(tmp_path):
+    rows = [
+        {
+            "Agente": "Agent",
+            "giorno": "2023-01-01",
+            "inizio_1": "08:00",
+            "fine_1": "12:00",
+            "inizio_2": float("nan"),
+            "fine_2": float("nan"),
+            "tipo": "NORMALE",
+            "note": "",
+        }
+    ]
+
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        pdf_path, html_path = df_to_pdf(rows, None)
+
+    html_text = Path(html_path).read_text()
+    assert "nan – nan" not in html_text
+
+    os.remove(pdf_path)
+    os.remove(html_path)
+
+
+def test_df_to_pdf_skips_nan_third_segment(tmp_path):
+    rows = [
+        {
+            "Agente": "Agent",
+            "giorno": "2023-01-01",
+            "inizio_1": "08:00",
+            "fine_1": "12:00",
+            "inizio_3": float("nan"),
+            "fine_3": float("nan"),
+            "tipo": "NORMALE",
+            "note": "",
+        }
+    ]
+
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        pdf_path, html_path = df_to_pdf(rows, None)
+
+    html_text = Path(html_path).read_text()
+    assert "nan – nan" not in html_text
+
+    os.remove(pdf_path)
+    os.remove(html_path)


### PR DESCRIPTION
## Summary
- add `_not_nan` helper for NaN checking
- skip NaN values when building extra segments in `df_to_pdf`
- test that NaN segments are omitted in generated HTML

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e728816f8832397ef6c35bb8d2a78