### PR TITLE
Include Google calendar events in shift PDF

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -10,6 +10,7 @@ import html as html_utils
 
 from app.models.user import User
 from app.schemas.turno import DAY_OFF_TYPES, TipoTurno
+from app.services.google_calendar import list_events_between
 
 
 def get_user_id(db: Session, agente: str) -> str:
@@ -240,6 +241,28 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
         if row.get("note"):
             notes[day].append(html_utils.escape(str(row.get("note"))))
 
+    # Load Google Calendar events for the week
+    gcal_notes: dict[str, list[str]] = {}
+    try:
+        events = list_events_between(
+            datetime.combine(week_start_date, time.min),
+            datetime.combine(week_end_date, time.max),
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        events = []
+
+    for ev in events:
+        if str(ev.get("id", "")).startswith("shift-"):
+            continue
+        day = ev.get("data_ora")
+        if isinstance(day, datetime):
+            key = day.date().strftime("%d/%m/%Y")
+            gcal_notes.setdefault(key, []).append(
+                html_utils.escape(str(ev.get("titolo")))
+            )
+
     # Generate HTML
     logo_path = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "..", "..", "static", "Logo.png")
@@ -291,7 +314,12 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
         cells = [f"<td>{weekday}<br>{day}</td>"]
         for a in agents:
             cells.append(f"<td>{by_date[day].get(a, '')}</td>")
-        note_text = "<br>".join(notes.get(day, []))
+        note_lines = notes.get(day, [])
+        g_lines = gcal_notes.get(day, [])
+        note_text = "<br>".join(note_lines)
+        if g_lines:
+            g_html = "<ul>" + "".join(f"<li>{l}</li>" for l in g_lines) + "</ul>"
+            note_text = f"{note_text}<br>{g_html}" if note_text else g_html
         cells.append(f"<td class='notes'>{note_text}</td>")
         rows_html.append("<tr>" + "".join(cells) + "</tr>")
 

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest.mock import patch
 import os
+from datetime import datetime
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -201,3 +202,57 @@ def test_week_pdf_escapes_html(setup_db, tmp_path):
     assert "&lt;b&gt;note&lt;/b&gt;" in captured["html_text"]
     assert "<Agent>" not in captured["html_text"]
     assert "<b>note</b>" not in captured["html_text"]
+
+
+def test_week_pdf_includes_gcal_events(setup_db, tmp_path):
+    headers, user_id = auth_user("gcal@example.com")
+
+    shift = {
+        "user_id": user_id,
+        "giorno": "2023-01-02",
+        "inizio_1": "08:00:00",
+        "fine_1": "12:00:00",
+        "inizio_2": None,
+        "fine_2": None,
+        "inizio_3": None,
+        "fine_3": None,
+        "tipo": TipoTurno.NORMALE.value,
+        "note": "",
+    }
+
+    client.post("/orari/", json=shift, headers=headers)
+
+    gcal_events = [
+        {
+            "id": "ev1",
+            "titolo": "Evento",
+            "descrizione": "",
+            "data_ora": datetime(2023, 1, 2, 10, 0),
+        },
+        {
+            "id": "shift-xyz",
+            "titolo": "Turno",
+            "descrizione": "",
+            "data_ora": datetime(2023, 1, 2, 8, 0),
+        },
+    ]
+
+    captured = {}
+    real_df_to_pdf = __import__("app.services.excel_import", fromlist=["df_to_pdf"]).df_to_pdf
+
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
+
+    def capture_df_to_pdf(rows, db):
+        pdf_path, html_path = real_df_to_pdf(rows, db)
+        captured["html_text"] = Path(html_path).read_text()
+        return pdf_path, html_path
+
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        with patch("app.services.google_calendar.list_events_between", lambda s, e: gcal_events):
+            with patch("app.routes.orari.df_to_pdf", side_effect=capture_df_to_pdf):
+                res = client.get("/orari/pdf?week=2023-W01", headers=headers)
+
+    assert res.status_code == 200
+    assert "<li>Evento</li>" in captured["html_text"]
+    assert "Turno" not in captured["html_text"]


### PR DESCRIPTION
## Summary
- add list_events_between() to Google calendar service
- include Google Calendar events in PDF generation
- show events as bullet points in "annotazioni di servizio"
- test that Google Calendar events appear in shift PDF

## Testing
- `pytest -k test_week_pdf_includes_gcal_events -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e73526394832390e873ac124c884a