### PR TITLE
Put Excel notes in PDF bullet list

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -322,12 +322,11 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
         cells = [f"<td>{weekday}<br>{day}</td>"]
         for a in agents:
             cells.append(f"<td>{by_date[day].get(a, '')}</td>")
-        note_lines = notes.get(day, [])
-        g_lines = gcal_notes.get(day, [])
-        note_text = "<br>".join(note_lines)
-        if g_lines:
-            g_html = "<ul>" + "".join(f"<li>{l}</li>" for l in g_lines) + "</ul>"
-            note_text = f"{note_text}<br>{g_html}" if note_text else g_html
+        note_lines = notes.get(day, []) + gcal_notes.get(day, [])
+        if note_lines:
+            note_text = "<ul>" + "".join(f"<li>{l}</li>" for l in note_lines) + "</ul>"
+        else:
+            note_text = ""
         cells.append(f"<td class='notes'>{note_text}</td>")
         rows_html.append("<tr>" + "".join(cells) + "</tr>")
 

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -598,3 +598,34 @@ def test_df_to_pdf_skips_nan_third_segment(tmp_path):
 
     os.remove(pdf_path)
     os.remove(html_path)
+
+
+def test_df_to_pdf_lists_notes(tmp_path):
+    rows = [
+        {
+            "Agente": "Agent",
+            "giorno": "2023-01-01",
+            "inizio_1": "08:00",
+            "fine_1": "12:00",
+            "tipo": "NORMALE",
+            "note": "prima"
+        },
+        {
+            "Agente": "Agent",
+            "giorno": "2023-01-01",
+            "inizio_1": "13:00",
+            "fine_1": "15:00",
+            "tipo": "NORMALE",
+            "note": "seconda"
+        },
+    ]
+
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        pdf_path, html_path = df_to_pdf(rows, None)
+
+    html_text = Path(html_path).read_text()
+    assert "<li>prima</li>" in html_text
+    assert "<li>seconda</li>" in html_text
+
+    os.remove(pdf_path)
+    os.remove(html_path)


### PR DESCRIPTION
## Summary
- render notes from Excel shifts as bullet points in the service annotations column
- cover bullet list behaviour with unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e75054f1c8323b75fcf9dc0cf6639