### PR TITLE
Add list_events_between function

### DIFF
--- a/app/services/google_calendar.py
+++ b/app/services/google_calendar.py
@@ -78,3 +78,75 @@ def list_upcoming_events(days: int) -> list[dict[str, Any]]:
         raise
     except Exception as exc:  # pragma: no cover - unexpected errors
         raise HTTPException(status_code=500, detail=str(exc))
+
+
+def list_events_between(start: datetime, end: datetime) -> list[dict[str, Any]]:
+    """Return Google Calendar events between ``start`` and ``end``.
+
+    Credentials and calendar ID are loaded from ``settings`` in the same way as
+    :func:`list_upcoming_events`.  When either is missing an empty list is
+    returned. ``data_ora`` fields in the returned dictionaries are ``datetime``
+    objects.
+    """
+
+    creds_json = settings.GOOGLE_CREDENTIALS_JSON
+    calendar_id = settings.GOOGLE_CALENDAR_ID
+    if not creds_json or not calendar_id:
+        return []
+
+    try:
+        from googleapiclient.discovery import build  # type: ignore
+        from google.oauth2.service_account import Credentials as SACredentials  # type: ignore
+        from google.oauth2.credentials import Credentials as UserCredentials  # type: ignore
+
+        if os.path.isfile(creds_json):
+            with open(creds_json, "r") as fh:
+                info = json.load(fh)
+        else:
+            info = json.loads(creds_json)
+
+        if info.get("type") == "service_account":
+            creds = SACredentials.from_service_account_info(
+                info,
+                scopes=["https://www.googleapis.com/auth/calendar.readonly"],
+            )
+        else:
+            creds = UserCredentials.from_authorized_user_info(info)
+
+        service = build("calendar", "v3", credentials=creds)
+        time_min = start.isoformat() + "Z"
+        time_max = end.isoformat() + "Z"
+        result = (
+            service.events()
+            .list(
+                calendarId=calendar_id,
+                timeMin=time_min,
+                timeMax=time_max,
+                singleEvents=True,
+                orderBy="startTime",
+            )
+            .execute()
+        )
+        items = []
+        for ev in result.get("items", []):
+            start_obj = ev.get("start", {})
+            when = start_obj.get("dateTime") or start_obj.get("date")
+            if not when:
+                continue
+            try:
+                dt = datetime.fromisoformat(when.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            items.append(
+                {
+                    "id": ev.get("id"),
+                    "titolo": ev.get("summary"),
+                    "descrizione": ev.get("description"),
+                    "data_ora": dt,
+                }
+            )
+        return items
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/tests/test_google_calendar_module.py
+++ b/tests/test_google_calendar_module.py
@@ -1,0 +1,86 @@
+import json
+from datetime import datetime
+import types
+
+import pytest
+
+from app.services import google_calendar
+
+
+def test_list_events_between_success(monkeypatch):
+    dummy_info = {"type": "service_account"}
+    monkeypatch.setattr(google_calendar.settings, "GOOGLE_CREDENTIALS_JSON", json.dumps(dummy_info))
+    monkeypatch.setattr(google_calendar.settings, "GOOGLE_CALENDAR_ID", "CAL")
+
+    monkeypatch.setattr(
+        "google.oauth2.service_account.Credentials.from_service_account_info",
+        lambda info, scopes=None: "CREDS",
+    )
+    monkeypatch.setattr(
+        "google.oauth2.credentials.Credentials.from_authorized_user_info",
+        lambda info: "CREDS",
+    )
+
+    captured = {}
+
+    class DummyEvents:
+        def list(self, **kwargs):
+            captured["params"] = kwargs
+
+            class Runner:
+                def execute(self_inner):
+                    return {
+                        "items": [
+                            {
+                                "id": "1",
+                                "summary": "A",
+                                "description": "desc",
+                                "start": {"dateTime": "2023-01-02T10:00:00Z"},
+                            },
+                            {
+                                "id": "2",
+                                "summary": "B",
+                                "description": "",
+                                "start": {"date": "2023-01-03"},
+                            },
+                        ]
+                    }
+
+            return Runner()
+
+    class DummyService:
+        def events(self):
+            return types.SimpleNamespace(list=DummyEvents().list)
+
+    monkeypatch.setattr("googleapiclient.discovery.build", lambda *a, **k: DummyService())
+
+    start = datetime(2023, 1, 1)
+    end = datetime(2023, 1, 7)
+
+    result = google_calendar.list_events_between(start, end)
+
+    assert captured["params"]["calendarId"] == "CAL"
+    assert captured["params"]["timeMin"].startswith("2023-01-01T")
+    assert captured["params"]["timeMax"].startswith("2023-01-07T")
+    assert len(result) == 2
+    assert result[0]["id"] == "1"
+    assert isinstance(result[0]["data_ora"], datetime)
+    assert result[1]["data_ora"].date() == datetime(2023, 1, 3).date()
+
+
+def test_list_events_between_missing_config(monkeypatch):
+    monkeypatch.setattr(google_calendar.settings, "GOOGLE_CREDENTIALS_JSON", None)
+    monkeypatch.setattr(google_calendar.settings, "GOOGLE_CALENDAR_ID", None)
+
+    called = {}
+
+    def fail_build(*a, **k):
+        called["yes"] = True
+        raise AssertionError
+
+    monkeypatch.setattr("googleapiclient.discovery.build", fail_build)
+
+    result = google_calendar.list_events_between(datetime.utcnow(), datetime.utcnow())
+
+    assert result == []
+    assert "yes" not in called


### PR DESCRIPTION
## Summary
- add `list_events_between` in `google_calendar` module
- export function to allow `excel_import` usage
- test new Google Calendar event listing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e8408544c8323a8e6e15a502c068b