### PR TITLE
Fix calendar deletion errors

### DIFF
--- a/app/crud/turno.py
+++ b/app/crud/turno.py
@@ -73,8 +73,12 @@ def remove_turno(db: Session, turno_id: UUID) -> None:
     """
     Elimina turno dal DB e rimuove l'evento corrispondente dal calendario Google.
     """
-    # 1. cancella evento su Google (ignora 404 se era già sparito)
-    gcal.delete_shift_event(turno_id)
+    # 1. cancella evento su Google (ignora eventuali errori)
+    try:
+        gcal.delete_shift_event(turno_id)
+    except Exception as exc:
+        # non bloccare l'operazione DB se G-Cal fallisce, ma loggare
+        logger.error("Errore sync calendario: %s", exc)
 
     # 2. cancella record dal DB
     deleted = db.query(Turno).filter_by(id=turno_id).delete()


### PR DESCRIPTION
## Summary
- guard Google Calendar delete event to avoid aborting DB deletion
- keep logging when calendar error occurs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e8acaf92c83238390cc6a42a7bea6