### PR TITLE
Update Google Calendar deletion parameters

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -150,6 +150,7 @@ def delete_shift_event(turno_id):
         gcal.events().delete(
             calendarId=cal_id,
             eventId=f"shift-{str(turno_id).replace('-', '')}",
+            sendUpdates="none",
         ).execute()
     except gerr.HttpError as e:
         if e.resp.status != 404:


### PR DESCRIPTION
## Summary
- suppress notifications when removing a shift event in `delete_shift_event`

## Testing
- `pytest tests/test_gcal.py::test_delete_shift_event_requires_calendar_id -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e8acc08008323ba0dc5d715584277