### PR TITLE
Center PDF header lines

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -292,9 +292,9 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
     header = f"""
     <div style='display:flex; align-items:center; justify-content:center; margin-bottom:10px;'>
         <img src='{logo_path}' alt='logo' style='width:70px; margin-right:8px;' />
-        <div>
-            COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE<br>
-            <span style='font-weight:bold; font-style:italic;'>ORARIO DI SERVIZIO – {start_date} – {end_date}</span>
+        <div style='text-align:center; width:100%;'>
+            <span style='display:block;'>COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE</span>
+            <span style='display:block; font-weight:bold; font-style:italic;'>ORARIO DI SERVIZIO – {start_date} – {end_date}</span>
         </div>
     </div>
     """


### PR DESCRIPTION
## Summary
- center PDF title and subtitle lines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e8b3374588323b19dcffa8febf988