### PR TITLE
Improve sync failure logging

### DIFF
--- a/app/crud/turno.py
+++ b/app/crud/turno.py
@@ -63,7 +63,12 @@ def upsert_turno(db: Session, payload: TurnoIn) -> Turno:
             gcal.sync_shift_event(rec)
         except Exception as exc:
             # non bloccare l’operazione DB se G-Cal fallisce, ma loggare
-            logger.error("Errore sync calendario: %s", exc)
+            logger.error(
+                "Errore sync calendario turno %s (event %s): %s",
+                rec.id,
+                gcal.make_event_id(rec.id),
+                exc,
+            )
 
     return rec
 


### PR DESCRIPTION
## Summary
- log turno id and calendar event id on sync failure
- provide gcal.make_event_id and use it for event operations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e8ad9d8008323bbb9b29e76aeb9b7