### PR TITLE
Add agent-specific colors for Google Calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 - `PDF_UPLOAD_ROOT` – directory where uploaded PDF files are stored.
 - `GOOGLE_CREDENTIALS_JSON` – JSON credentials (or path) for Google APIs.
 - `GOOGLE_CALENDAR_ID` – ID of the calendar to read events from.
-- `G_SHIFT_CAL_ID` – ID of the Google Calendar used for shift syncs.
+- `G_SHIFT_CAL_ID` – ID of the Google Calendar used for shift syncs. Colors for
+  shift events are assigned per agent using the `AGENT_COLORS` mapping defined
+  in `app/services/gcal.py`. Agents not listed there fall back to a
+  hash-based color.
 - `GOOGLE_CLIENT_ID` – OAuth client ID for verifying Google sign-in tokens.
 - `CORS_ORIGINS` – (optional) comma separated list of allowed origins for
   cross-origin requests. Defaults to `"*"`.

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -169,4 +169,16 @@ def test_sync_shift_event_sets_color_from_user(monkeypatch):
 
     gcal.sync_shift_event(turno)
 
-    assert captured["color"] == gcal.color_for_user("u1")
+    assert captured["color"] == gcal.color_for_user(user)
+
+
+@pytest.mark.parametrize(
+    "email,expected",
+    [
+        ("marco@comune.castione.bg.it", "1"),
+        ("rossella@comune.castione.bg.it", "6"),
+        ("mattia@comune.castione.bg.it", "7"),
+    ],
+)
+def test_color_for_user_predefined_agents(email, expected):
+    assert gcal.color_for_user(email) == expected


### PR DESCRIPTION
## Summary
- assign Google Calendar colors with new `AGENT_COLORS` mapping
- determine color by agent email before hashed fallback
- pass user object to `color_for_user` when syncing shifts
- test predefined agent colors
- document customizable mapping in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e8b723a2083238781d8dc3220898f