### PR TITLE
Add public events to shift PDF

### DIFF
--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -256,3 +256,64 @@ def test_week_pdf_includes_gcal_events(setup_db, tmp_path):
     assert res.status_code == 200
     assert "<li>Evento</li>" in captured["html_text"]
     assert "Turno" not in captured["html_text"]
+
+
+def test_week_pdf_includes_public_events(setup_db, tmp_path):
+    headers, user_id = auth_user("events@example.com")
+
+    shift = {
+        "user_id": user_id,
+        "giorno": "2023-01-02",
+        "inizio_1": "08:00:00",
+        "fine_1": "12:00:00",
+        "inizio_2": None,
+        "fine_2": None,
+        "inizio_3": None,
+        "fine_3": None,
+        "tipo": TipoTurno.NORMALE.value,
+        "note": "",
+    }
+
+    client.post("/orari/", json=shift, headers=headers)
+
+    client.post(
+        "/events/",
+        json={
+            "titolo": "Pubblico",
+            "descrizione": "",
+            "data_ora": "2023-01-02T10:00:00",
+            "is_public": True,
+        },
+        headers=headers,
+    )
+
+    client.post(
+        "/events/",
+        json={
+            "titolo": "Privato",
+            "descrizione": "",
+            "data_ora": "2023-01-02T11:00:00",
+            "is_public": False,
+        },
+        headers=headers,
+    )
+
+    captured = {}
+    real_df_to_pdf = __import__("app.services.excel_import", fromlist=["df_to_pdf"]).df_to_pdf
+
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
+
+    def capture_df_to_pdf(rows, db):
+        pdf_path, html_path = real_df_to_pdf(rows, db)
+        captured["html_text"] = Path(html_path).read_text()
+        return pdf_path, html_path
+
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        with patch("app.services.google_calendar.list_events_between", lambda s, e: []):
+            with patch("app.routes.orari.df_to_pdf", side_effect=capture_df_to_pdf):
+                res = client.get("/orari/pdf?week=2023-W01", headers=headers)
+
+    assert res.status_code == 200
+    assert "<li>Pubblico</li>" in captured["html_text"]
+    assert "Privato" not in captured["html_text"]


### PR DESCRIPTION
## Summary
- include Event model in Excel import service
- fetch public events for the week when building the PDF
- list those events in the `Annotazioni di servizio` column
- test that public events are shown in the PDF

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e8c56485883239381055a8c68295b