### PR TITLE
Deterministic calendar color hashing

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -9,6 +9,7 @@ Richiede:
 from datetime import date, time, datetime
 from functools import lru_cache
 from app.config import settings
+import hashlib
 
 import json
 import os
@@ -102,7 +103,8 @@ def color_for_user(user) -> str:
         user_id = user
 
     colors = [str(i) for i in range(1, 12)]
-    idx = abs(hash(user_id)) % len(colors)
+    digest = hashlib.sha1(str(user_id).encode()).hexdigest()
+    idx = int(digest, 16) % len(colors)
     return colors[idx]
 
 

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -169,7 +169,7 @@ def test_sync_shift_event_sets_color_from_user(monkeypatch):
 
     gcal.sync_shift_event(turno)
 
-    assert captured["color"] == gcal.color_for_user(user)
+    assert captured["color"] == "11"
 
 
 @pytest.mark.parametrize(
@@ -182,3 +182,8 @@ def test_sync_shift_event_sets_color_from_user(monkeypatch):
 )
 def test_color_for_user_predefined_agents(email, expected):
     assert gcal.color_for_user(email) == expected
+
+
+def test_color_for_user_deterministic():
+    """Unknown users should receive a deterministic color."""
+    assert gcal.color_for_user("a@example.com") == "11"


### PR DESCRIPTION
## Summary
- ensure Google Calendar colors use stable SHA1-based hash
- adjust color for sync_shift_event test
- check deterministic colors for unknown users

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e8e3d39a88323873cb591e13eabe7