### PR TITLE
Remove unused SHIFT_CAL_ID variable

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -53,7 +53,6 @@ def get_client():
 
 
 # ------------------------------------------------------------------- calendar ID
-SHIFT_CAL_ID = settings.G_SHIFT_CAL_ID  # calendario "Turni di Servizio"
 
 
 # ------------------------------------------------------------------- utilità


### PR DESCRIPTION
## Summary
- delete the leftover `SHIFT_CAL_ID` variable assignment in `gcal.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e8e3974608323baa27ab1198a0b33