### PR TITLE
Add log on day-off shift removal

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -125,6 +125,7 @@ def sync_shift_event(turno):
     if tipo in DAY_OFF_TYPES:
         # remove any existing calendar event for day-off records
         delete_shift_event(turno.id)
+        logger.info("Removed calendar event for day off: %s", turno.id)
         return
 
     # Google Calendar limita l'alfabeto degli identificativi degli eventi a

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -206,6 +206,27 @@ def _dummy_turno():
     )
 
 
+def test_sync_shift_event_logs_day_off(monkeypatch, caplog):
+    """Day-off turni should remove any calendar event and log the action."""
+
+    deleted = {}
+
+    def fake_delete(turno_id):
+        deleted["id"] = turno_id
+
+    monkeypatch.setattr(gcal, "delete_shift_event", fake_delete)
+    monkeypatch.setattr(gcal.settings, "G_SHIFT_CAL_ID", "CAL")
+
+    turno = _dummy_turno()
+    turno.tipo = gcal.TipoTurno.RECUPERO.value
+
+    with caplog.at_level(logging.INFO):
+        gcal.sync_shift_event(turno)
+
+    assert deleted.get("id") == turno.id
+    assert "Removed calendar event for day off" in caplog.text
+
+
 def test_sync_shift_event_logs_warning_on_update_404(monkeypatch, caplog):
     """An update failure with status 404 should log a warning and insert."""
 


### PR DESCRIPTION
## Summary
- log when sync_shift_event removes an event for a day off
- test that the log is emitted when a day-off shift is synced

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e9898eab48323889427bd6e3b7a36