### PR TITLE
Add info logging for calendar events

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -155,6 +155,7 @@ def sync_shift_event(turno):
             eventId=evt_id,
             body=body,
         ).execute()
+        logger.info("Updated event %s", evt_id)
     except gerr.HttpError as e:
         if e.resp.status in (404, 400):
             # status 400 may be returned when Google thinks the event ID is invalid,
@@ -166,6 +167,7 @@ def sync_shift_event(turno):
                     body=body,
                     sendUpdates="none",
                 ).execute()
+                logger.info("Inserted event %s", evt_id)
             except gerr.HttpError as e2:
                 logger.error("Failed to insert event %s: %s", evt_id, e2)
                 raise
@@ -190,6 +192,7 @@ def delete_shift_event(turno_id):
             eventId=f"shift-{str(turno_id).replace('-', '')}",
             sendUpdates="none",
         ).execute()
+        logger.info("Deleted event %s", turno_id)
     except gerr.HttpError as e:
         if e.resp.status == 404:
             logger.warning("Delete of event %s returned 404", turno_id)

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -350,3 +350,84 @@ def test_delete_shift_event_reraises_errors(monkeypatch, caplog):
             gcal.delete_shift_event("1")
 
     assert "Failed to delete event" in caplog.text
+
+
+def test_sync_shift_event_logs_info_on_update_success(monkeypatch, caplog):
+    """Successful update should log an info message."""
+
+    def fake_update(**kwargs):
+        class Runner:
+            def execute(self_inner):
+                pass
+
+        return Runner()
+
+    class DummyClient:
+        def events(self):
+            return types.SimpleNamespace(update=fake_update)
+
+    monkeypatch.setattr(gcal, "get_client", lambda: DummyClient())
+    monkeypatch.setattr(gcal.settings, "G_SHIFT_CAL_ID", "CAL")
+
+    turno = _dummy_turno()
+
+    with caplog.at_level(logging.INFO):
+        gcal.sync_shift_event(turno)
+
+    assert "Updated event" in caplog.text
+
+
+def test_sync_shift_event_logs_info_on_insert_success(monkeypatch, caplog):
+    """When update fails but insert succeeds, an info message should be logged."""
+
+    def fake_update(**kwargs):
+        class Runner:
+            def execute(self_inner):
+                raise FakeHttpError(404)
+
+        return Runner()
+
+    def fake_insert(**kwargs):
+        class Runner:
+            def execute(self_inner):
+                pass
+
+        return Runner()
+
+    class DummyClient:
+        def events(self):
+            return types.SimpleNamespace(update=fake_update, insert=fake_insert)
+
+    monkeypatch.setattr(gcal, "get_client", lambda: DummyClient())
+    monkeypatch.setattr(gcal.gerr, "HttpError", FakeHttpError, raising=False)
+    monkeypatch.setattr(gcal.settings, "G_SHIFT_CAL_ID", "CAL")
+
+    turno = _dummy_turno()
+
+    with caplog.at_level(logging.INFO):
+        gcal.sync_shift_event(turno)
+
+    assert "Inserted event" in caplog.text
+
+
+def test_delete_shift_event_logs_info_on_success(monkeypatch, caplog):
+    """Successful deletions should be logged at info level."""
+
+    def fake_delete(**kwargs):
+        class Runner:
+            def execute(self_inner):
+                pass
+
+        return Runner()
+
+    class DummyClient:
+        def events(self):
+            return types.SimpleNamespace(delete=fake_delete)
+
+    monkeypatch.setattr(gcal, "get_client", lambda: DummyClient())
+    monkeypatch.setattr(gcal.settings, "G_SHIFT_CAL_ID", "CAL")
+
+    with caplog.at_level(logging.INFO):
+        gcal.delete_shift_event("1")
+
+    assert "Deleted event" in caplog.text


### PR DESCRIPTION
## Summary
- log successful calendar updates, inserts, and deletions
- test the new info messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e9895bdf8832381943c66a6bee6e3