### PR TITLE
Use logger.exception for calendar sync errors

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -167,10 +167,10 @@ def sync_shift_event(turno):
                     sendUpdates="none",
                 ).execute()
             except gerr.HttpError as e2:
-                logger.error("Failed to insert event %s: %s", evt_id, e2)
+                logger.exception("Failed to insert event %s", evt_id)
                 raise
         else:
-            logger.error("Failed to update event %s: %s", evt_id, e)
+            logger.exception("Failed to update event %s", evt_id)
             raise
 
 
@@ -194,5 +194,5 @@ def delete_shift_event(turno_id):
         if e.resp.status == 404:
             logger.warning("Delete of event %s returned 404", turno_id)
         else:
-            logger.error("Failed to delete event %s: %s", turno_id, e)
+            logger.exception("Failed to delete event %s", turno_id)
             raise


### PR DESCRIPTION
## Summary
- log exceptions in Google Calendar helper with `logger.exception`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e989a80f88323a95cd69fc940215d