### PR TITLE
Fix deterministic calendar color hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 - `G_SHIFT_CAL_ID` – ID of the Google Calendar used for shift syncs. Colors for
   shift events are assigned per agent using the `AGENT_COLORS` mapping defined
   in `app/services/gcal.py`. Agents not listed there fall back to a
-  hash-based color.
+  deterministic hash-based color.
 - `GOOGLE_CLIENT_ID` – OAuth client ID for verifying Google sign-in tokens.
 - `CORS_ORIGINS` – (optional) comma separated list of allowed origins for
   cross-origin requests. Defaults to `"*"`.

--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -8,6 +8,7 @@ Richiede:
 
 from datetime import date, time, datetime
 from functools import lru_cache
+import hashlib
 from app.config import settings
 import logging
 
@@ -104,7 +105,8 @@ def color_for_user(user) -> str:
         user_id = user
 
     colors = [str(i) for i in range(1, 12)]
-    idx = abs(hash(user_id)) % len(colors)
+    digest = hashlib.sha1(user_id.encode("utf-8")).digest()
+    idx = int.from_bytes(digest[:4], "big") % len(colors)
     return colors[idx]
 
 

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -185,6 +185,12 @@ def test_color_for_user_predefined_agents(email, expected):
     assert gcal.color_for_user(email) == expected
 
 
+def test_color_for_user_unknown_is_deterministic():
+    """Colors for unknown users should be stable."""
+    assert gcal.color_for_user("bot@example.com") == "6"
+
+
+
 class FakeHttpError(Exception):
     def __init__(self, status):
         self.resp = types.SimpleNamespace(status=status)


### PR DESCRIPTION
## Summary
- hash email addresses with SHA1 for stable color IDs
- document deterministic color behavior
- test that unknown user colors are deterministic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e98a868688323b5130c7790874893