### PR TITLE
Fix header width in PDF export

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -307,11 +307,11 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
     """
 
     header = f"""
-    <div style='display:flex; align-items:center; justify-content:center; margin-bottom:10px;'>
+    <div style='display:flex; align-items:center; margin-bottom:10px;'>
         <img src='{logo_path}' alt='logo' style='width:70px; margin-right:8px;' />
-        <div style='text-align:center; width:100%;'>
-            <span style='display:block;'>COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE</span>
-            <span style='display:block; font-weight:bold; font-style:italic;'>ORARIO DI SERVIZIO – {start_date} – {end_date}</span>
+        <div style='display:flex; flex-direction:column;'>
+            <span>COMUNE DI CASTIONE DELLA PRESOLANA – SERVIZIO DI POLIZIA LOCALE</span>
+            <span style='font-weight:bold; font-style:italic;'>ORARIO DI SERVIZIO – {start_date} – {end_date}</span>
         </div>
     </div>
     """


### PR DESCRIPTION
## Summary
- stop forcing width in PDF header

## Testing
- `pytest tests/test_orari_pdf.py tests/test_excel_import.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ecabb58708323a38a1ed19bc3dacb