### PR TITLE
Validate user names

### DIFF
--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -13,6 +13,10 @@ def create_user(db: Session, email: str, password: str, nome: str):
     if existing_user:
         raise HTTPException(status_code=409, detail="Email already registered")
 
+    nome = nome.strip()
+    if not nome:
+        raise HTTPException(status_code=400, detail="Invalid nome")
+
     hashed_password = pwd_context.hash(password)
     db_user = User(
         id=str(uuid.uuid4()),

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, constr
 from uuid import UUID
 from app.schemas.turno import TurnoOut
 
@@ -6,7 +6,7 @@ from app.schemas.turno import TurnoOut
 class UserCreate(BaseModel):
     email: str
     password: str
-    nome: str
+    nome: constr(strip_whitespace=True, min_length=1)
 
 
 class UserCredentials(BaseModel):

--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -141,7 +141,9 @@ def sync_shift_event(turno):
     start = first_non_null(turno.inizio_1, turno.inizio_2, turno.inizio_3)
     end = last_non_null(turno.fine_3, turno.fine_2, turno.fine_1)
 
-    title_name = turno.user.nome or turno.user.email.split("@")[0]
+    title_name = (turno.user.nome or "").strip()
+    if not title_name:
+        title_name = turno.user.email.split("@")[0]
     body = {
         "id": evt_id,
         "summary": f"{start.strftime('%H:%M')} {title_name}",
@@ -163,7 +165,9 @@ def sync_shift_event(turno):
         if e.resp.status in (404, 400):
             # status 400 may be returned when Google thinks the event ID is invalid,
             # so treat it like a missing event and create it from scratch
-            logger.warning("Update of event %s failed (%s), inserting", evt_id, e.resp.status)
+            logger.warning(
+                "Update of event %s failed (%s), inserting", evt_id, e.resp.status
+            )
             try:
                 gcal.events().insert(
                     calendarId=cal_id,

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -119,3 +119,11 @@ def test_get_current_user_missing_header():
     response = client.get("/users/me")
     assert response.status_code == 401
     assert response.json()["detail"] == "Authorization header missing"
+
+
+def test_create_user_rejects_blank_nome():
+    response = client.post(
+        "/users/",
+        json={"email": "blank@example.com", "password": "secret", "nome": "   "},
+    )
+    assert response.status_code in (400, 422)


### PR DESCRIPTION
## Summary
- enforce trimmed `nome` in user creation schema
- strip names in user creation CRUD and reject empty strings
- prevent blank names in calendar updates
- test user creation with blank name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ecb77caac8323902f11532b3b841e