### PR TITLE
Fix case-insensitive user lookup

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -4,6 +4,7 @@ import tempfile
 from datetime import datetime, timedelta, time
 from typing import Any, Dict, List, Tuple
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 from fastapi import HTTPException
 import os
 import html as html_utils
@@ -21,7 +22,11 @@ def get_user_id(db: Session, agente: str) -> str:
         raise ValueError("A database session is required to resolve users")
 
     name = agente.strip()
-    user = db.query(User).filter(User.nome == name).first()
+    user = (
+        db.query(User)
+        .filter(func.lower(User.nome) == name.lower())
+        .first()
+    )
     if not user:
         raise ValueError(f"Unknown user: {agente}")
     return str(user.id)

--- a/tests/test_excel_import.py
+++ b/tests/test_excel_import.py
@@ -110,7 +110,7 @@ def test_parse_excel_with_db(tmp_path):
     df = pd.DataFrame(
         [
             {
-                "Agente": "Agent X",
+                "Agente": "agent x",
                 "Giorno": "2023-01-03",
                 "Inizio1": "07:00:00",
                 "Fine1": "11:00:00",

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -27,7 +27,7 @@ def test_import_xlsx_creates_turni_and_returns_pdf(setup_db, tmp_path):
     df = pd.DataFrame(
         [
             {
-                "Agente": nome,
+                "Agente": nome.upper(),
                 "Data": "2023-01-01",
                 "Inizio1": "08:00:00",
                 "Fine1": "12:00:00",


### PR DESCRIPTION
## Summary
- ensure `excel_import.get_user_id` compares usernames using lowercase
- test that name lookup works with varying case

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ed29ba3b48323b6b4490db74b05d6