### PR TITLE
Adjust GCAL log levels

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -165,7 +165,7 @@ def sync_shift_event(turno):
         if e.resp.status in (404, 400):
             # status 400 may be returned when Google thinks the event ID is invalid,
             # so treat it like a missing event and create it from scratch
-            logger.warning(
+            logger.info(
                 "Update of event %s failed (%s), inserting", evt_id, e.resp.status
             )
             try:
@@ -202,7 +202,7 @@ def delete_shift_event(turno_id):
         logger.info("Deleted event %s", turno_id)
     except gerr.HttpError as e:
         if e.resp.status == 404:
-            logger.warning("Delete of event %s returned 404", turno_id)
+            logger.info("Delete of event %s returned 404", turno_id)
         else:
             logger.exception("Failed to delete event %s", turno_id)
             raise

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -233,8 +233,8 @@ def test_sync_shift_event_logs_day_off(monkeypatch, caplog):
     assert "Removed calendar event for day off" in caplog.text
 
 
-def test_sync_shift_event_logs_warning_on_update_404(monkeypatch, caplog):
-    """An update failure with status 404 should log a warning and insert."""
+def test_sync_shift_event_logs_info_on_update_404(monkeypatch, caplog):
+    """An update failure with status 404 should log an info message and insert."""
 
     insert_called = {}
 
@@ -262,7 +262,7 @@ def test_sync_shift_event_logs_warning_on_update_404(monkeypatch, caplog):
 
     turno = _dummy_turno()
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         gcal.sync_shift_event(turno)
 
     assert insert_called.get("called") is True
@@ -330,8 +330,8 @@ def test_sync_shift_event_insert_failure_reraised(monkeypatch, caplog):
     assert "Failed to insert event" in caplog.text
 
 
-def test_delete_shift_event_logs_warning_on_404(monkeypatch, caplog):
-    """Deletion errors with 404 should only log a warning."""
+def test_delete_shift_event_logs_info_on_404(monkeypatch, caplog):
+    """Deletion errors with 404 should only log an info message."""
 
     def fake_delete(**kwargs):
         class Runner:
@@ -348,7 +348,7 @@ def test_delete_shift_event_logs_warning_on_404(monkeypatch, caplog):
     monkeypatch.setattr(gcal.gerr, "HttpError", FakeHttpError, raising=False)
     monkeypatch.setattr(gcal.settings, "G_SHIFT_CAL_ID", "CAL")
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         gcal.delete_shift_event("1")
 
     assert "Delete of event" in caplog.text


### PR DESCRIPTION
## Summary
- log update failures and delete 404s at info level
- update tests to expect info-level logs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ed34ba2cc83239e457700d6696778