### PR TITLE
Implement short names for calendar events

### DIFF
--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -9,6 +9,7 @@ from app.schemas.event import EventResponse
 from app.schemas.todo import ToDoResponse
 from app.crud import event, todo
 from app.services.google_calendar import list_upcoming_events
+from app.services import gcal
 
 router = APIRouter(prefix="/dashboard", tags=["Dashboard"])
 
@@ -42,7 +43,7 @@ def upcoming_events(
 
     gcal_raw = list_upcoming_events(days)
 
-    me_name = (current_user.nome or current_user.email.split("@")[0]).strip().lower()
+    me_name = gcal.short_name_for_user(current_user).lower()
 
     def include_event(item: dict) -> bool:
         title = item.get("titolo", "")

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -133,6 +133,43 @@ def test_shift_event_summary_email(setup_db):
     assert captured["body"]["summary"] == "08:00 Calendar User"
 
 
+def test_shift_event_summary_short_name(setup_db):
+    headers, user_id = auth_user(
+        "marco@comune.castione.bg.it", nome="Ag.Sc. Fenaroli Marco"
+    )
+
+    captured = {}
+
+    class DummyClient:
+        def events(self):
+            class Events:
+                def update(self, calendarId=None, eventId=None, body=None):
+                    captured["body"] = body
+                    return MagicMock(execute=MagicMock())
+
+            return Events()
+
+    with patch("app.services.gcal.get_client", return_value=DummyClient()):
+        client.post(
+            "/orari/",
+            json={
+                "user_id": user_id,
+                "giorno": "2023-05-05",
+                "inizio_1": "08:00:00",
+                "fine_1": "12:00:00",
+                "inizio_2": None,
+                "fine_2": None,
+                "inizio_3": None,
+                "fine_3": None,
+                "tipo": TipoTurno.NORMALE.value,
+                "note": "",
+            },
+            headers=headers,
+        )
+
+    assert captured["body"]["summary"] == "08:00 Marco"
+
+
 def test_create_turno_unknown_user_returns_400(setup_db):
     headers, _ = auth_user("u@example.com")
 


### PR DESCRIPTION
## Summary
- show a short name instead of an email address in event titles
- update dashboard filtering to match these short names
- test that mapped addresses use the configured short name

## Testing
- `pytest tests/test_turni.py::test_shift_event_summary_short_name -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ed90789348323b889b22221005013