### PR TITLE
Filter Google events that are other users' names

### DIFF
--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -43,13 +43,20 @@ def upcoming_events(
     gcal_raw = list_upcoming_events(days)
 
     me_name = (current_user.nome or current_user.email.split("@")[0]).strip().lower()
+    other_names = {
+        n.strip().lower()
+        for (n,) in db.query(User.nome).filter(User.id != current_user.id).all()
+        if n
+    }
 
     def include_event(item: dict) -> bool:
-        title = item.get("titolo", "")
+        title = (item.get("titolo") or "").strip().lower()
         m = re.match(r"^(\d{1,2}:\d{2})\s+(.+)$", title)
         if m:
             who = m.group(2).strip().lower()
             return who == me_name
+        if title in other_names:
+            return False
         return True
 
     gcal_items = [

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -76,6 +76,12 @@ def test_dashboard_upcoming(monkeypatch, setup_db):
             "descrizione": "",
             "data_ora": now + timedelta(days=3),
         },
+        {
+            "id": "g4",
+            "titolo": "Luigi",
+            "descrizione": "",
+            "data_ora": now + timedelta(days=4),
+        },
     ]
     monkeypatch.setattr(
         "app.services.google_calendar.list_upcoming_events", lambda days: google_events
@@ -86,5 +92,6 @@ def test_dashboard_upcoming(monkeypatch, setup_db):
     data = res.json()
     assert len(data) == 4
     assert [item["kind"] for item in data] == ["event", "google", "todo", "google"]
+    assert all(item.get("id") != "g4" for item in data)
     times = [item["data_ora"] for item in data]
     assert times == sorted(times)


### PR DESCRIPTION
## Summary
- exclude Google Calendar events whose title matches another user's name
- test that events titled with other user names are not returned in dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ed98db94c8323987a39a0c386087b