### PR TITLE
Handle Google event titles with dots and spaces

### DIFF
--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -46,8 +46,8 @@ def upcoming_events(
     me_name = gcal.short_name_for_user(current_user).lower()
 
     def include_event(item: dict) -> bool:
-        title = item.get("titolo", "")
-        m = re.match(r"^(\d{1,2}:\d{2})\s+(.+)$", title)
+        title = item.get("titolo", "").strip()
+        m = re.match(r"^(\d{1,2}[:.]\d{2})\s+(.+)$", title)
         if m:
             who = m.group(2).strip().lower()
             return who == me_name

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -60,7 +60,7 @@ def test_dashboard_upcoming(monkeypatch, setup_db):
     google_events = [
         {
             "id": "g1",
-            "titolo": "09:00 Mario",
+            "titolo": " 09.00 Mario ",
             "descrizione": "",
             "data_ora": now + timedelta(days=1),
         },


### PR DESCRIPTION
## Summary
- improve `include_event` to accept `hh.mm` or `hh:mm` formats and trim whitespace
- update dashboard test for `09.00 Mario` with extra spaces

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686edc120a888323a05c471d4aa20b45