### PR TITLE
Update agent color map

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -27,9 +27,9 @@ logger = logging.getLogger(__name__)
 # These values are used by ``color_for_user`` when the matching key is found.
 # Any user not listed here falls back to a hash-based color selection.
 AGENT_COLORS = {
-    "marco@comune.castione.bg.it": "1",
-    "rossella@comune.castione.bg.it": "6",
-    "mattia@comune.castione.bg.it": "7",
+    "marco@comune.castione.bg.it": "7",
+    "rossella@comune.castione.bg.it": "3",
+    "mattia@comune.castione.bg.it": "5",
 }
 
 # Short names to use for specific agents in calendar event summaries. When a

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -176,9 +176,9 @@ def test_sync_shift_event_sets_color_from_user(monkeypatch):
 @pytest.mark.parametrize(
     "email,expected",
     [
-        ("marco@comune.castione.bg.it", "1"),
-        ("rossella@comune.castione.bg.it", "6"),
-        ("mattia@comune.castione.bg.it", "7"),
+        ("marco@comune.castione.bg.it", "7"),
+        ("rossella@comune.castione.bg.it", "3"),
+        ("mattia@comune.castione.bg.it", "5"),
     ],
 )
 def test_color_for_user_predefined_agents(email, expected):


### PR DESCRIPTION
## Summary
- adjust `AGENT_COLORS` mapping for Marco, Rossella and Mattia
- update unit test expectations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ed945faac83239725a563bebe435e