### PR TITLE
Change Google Calendar event format

### DIFF
--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -45,12 +45,19 @@ def upcoming_events(
 
     me_name = gcal.short_name_for_user(current_user).lower()
 
+    known_agents = {n.lower() for n in gcal.AGENT_SHORT_NAMES.values()}
+
     def include_event(item: dict) -> bool:
         title = item.get("titolo", "").strip()
         m = re.match(r"^(\d{1,2}[:.]\d{2})\s+(.+)$", title)
         if m:
             who = m.group(2).strip().lower()
             return who == me_name
+
+        low = title.lower()
+        if low in known_agents:
+            return low == me_name
+
         return True
 
     gcal_items = [

--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -172,8 +172,8 @@ def sync_shift_event(turno):
     title_name = short_name_for_user(turno.user)
     body = {
         "id": evt_id,
-        "summary": f"{start.strftime('%H:%M')} {title_name}",
-        "description": turno.note or "",
+        "summary": title_name,
+        "description": f"Turno servizio {title_name}",
         "start": {"dateTime": iso_dt(turno.giorno, start)},
         "end": {"dateTime": iso_dt(turno.giorno, end)},
         "colorId": color_for_user(turno.user),

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -60,13 +60,13 @@ def test_dashboard_upcoming(monkeypatch, setup_db):
     google_events = [
         {
             "id": "g1",
-            "titolo": " 09.00 Mario ",
+            "titolo": "Mario",
             "descrizione": "",
             "data_ora": now + timedelta(days=1),
         },
         {
             "id": "g2",
-            "titolo": "08:00 Luigi",
+            "titolo": "Luigi",
             "descrizione": "",
             "data_ora": now + timedelta(days=2),
         },

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -130,7 +130,7 @@ def test_shift_event_summary_email(setup_db):
             headers=headers,
         )
 
-    assert captured["body"]["summary"] == "08:00 Calendar User"
+    assert captured["body"]["summary"] == "Calendar User"
 
 
 def test_shift_event_summary_short_name(setup_db):
@@ -167,7 +167,7 @@ def test_shift_event_summary_short_name(setup_db):
             headers=headers,
         )
 
-    assert captured["body"]["summary"] == "08:00 Marco"
+    assert captured["body"]["summary"] == "Marco"
 
 
 def test_create_turno_unknown_user_returns_400(setup_db):


### PR DESCRIPTION
## Summary
- adjust Google Calendar event body fields
- filter dashboard events based on short names only
- update unit tests for new format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ee11b9b9c8323a7b5241558f97f07