### PR TITLE
chore: drop unused httpx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repository contains a FastAPI backend used by Segretaria Digitale.
 ## Setup
 
 1. Ensure you have **Python 3.10–3.11** installed.
-2. Create a virtual environment and install dependencies (including `httpx`,
-   `pandas`, `openpyxl`, `WeasyPrint==60.1` and `pydyf==0.8.0`):
+2. Create a virtual environment and install dependencies (including `pandas`,
+   `openpyxl`, `WeasyPrint==60.1` and `pydyf==0.8.0`):
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ passlib[bcrypt]==1.7.4
 bcrypt==3.2.2
 python-jose[cryptography]==3.3.0
 psycopg2-binary==2.9.9
-httpx==0.27.0
 alembic==1.13.1
 python-multipart==0.0.9
 google-api-python-client==2.126.0


### PR DESCRIPTION
## Summary
- remove httpx from requirements
- clean up README setup instructions

## Testing
- `./scripts/test.sh` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ee81a2a748323922ddaa2a73dc6f7