### PR TITLE
Fix remove_turno import

### DIFF
--- a/app/crud/turno.py
+++ b/app/crud/turno.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 from app.models.turno import Turno  # modello ORM
 from app.models.user import User
-from app.schemas.turno import TurnoIn, TipoTurno  # Pydantic (input)
+from app.schemas.turno import DAY_OFF_TYPES, TurnoIn, TipoTurno  # Pydantic (input)
 from app.services import gcal
 
 


### PR DESCRIPTION
## Summary
- import `DAY_OFF_TYPES` in the turno CRUD module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68702ef54d788323879b8b1a2bf599d0