### PR TITLE
Fix shift event summary

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -169,10 +169,10 @@ def sync_shift_event(turno):
     start = first_non_null(turno.inizio_1, turno.inizio_2, turno.inizio_3)
     end = last_non_null(turno.fine_3, turno.fine_2, turno.fine_1)
 
-    title_name = short_name_for_user(turno.user)
+    title_name = getattr(turno.user, "nome", "")
     body = {
         "id": evt_id,
-        "summary": title_name,
+        "summary": f"Turno {title_name}",
         "description": f"Turno servizio {title_name}",
         "start": {"dateTime": iso_dt(turno.giorno, start)},
         "end": {"dateTime": iso_dt(turno.giorno, end)},

--- a/tests/test_turni.py
+++ b/tests/test_turni.py
@@ -130,7 +130,7 @@ def test_shift_event_summary_email(setup_db):
             headers=headers,
         )
 
-    assert captured["body"]["summary"] == "Calendar User"
+    assert captured["body"]["summary"] == "Turno Calendar User"
 
 
 def test_shift_event_summary_short_name(setup_db):
@@ -167,7 +167,7 @@ def test_shift_event_summary_short_name(setup_db):
             headers=headers,
         )
 
-    assert captured["body"]["summary"] == "Marco"
+    assert captured["body"]["summary"] == "Turno Ag.Sc. Fenaroli Marco"
 
 
 def test_create_turno_unknown_user_returns_400(setup_db):


### PR DESCRIPTION
## Summary
- fix creation of calendar event titles
- update event body to prefix with "Turno"
- adjust tests for new summary text

## Testing
- `scripts/test.sh` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6870321e7c488323b2788bb35601738b