### PR TITLE
Filter 'turno' GCAL events

### DIFF
--- a/app/services/excel_import.py
+++ b/app/services/excel_import.py
@@ -285,10 +285,12 @@ def df_to_pdf(rows: List[Dict[str, Any]], db: Session | None = None) -> Tuple[st
     for ev in events:
         if str(ev.get("id", "")).startswith("shift-"):
             continue
+        title = ev.get("titolo")
+        if isinstance(title, str) and title.strip().lower().startswith("turno"):
+            continue
         day = ev.get("data_ora")
         if isinstance(day, datetime):
             key = day.date().strftime("%d/%m/%Y")
-            title = ev.get("titolo")
             if title:
                 clean = _strip_emails(str(title))
                 if clean:

--- a/tests/test_orari_pdf.py
+++ b/tests/test_orari_pdf.py
@@ -258,6 +258,53 @@ def test_week_pdf_includes_gcal_events(setup_db, tmp_path):
     assert "Turno" not in captured["html_text"]
 
 
+def test_week_pdf_excludes_turno_titles(setup_db, tmp_path):
+    headers, user_id = auth_user("turnotitle@example.com")
+
+    shift = {
+        "user_id": user_id,
+        "giorno": "2023-01-02",
+        "inizio_1": "08:00:00",
+        "fine_1": "12:00:00",
+        "inizio_2": None,
+        "fine_2": None,
+        "inizio_3": None,
+        "fine_3": None,
+        "tipo": TipoTurno.NORMALE.value,
+        "note": "",
+    }
+
+    client.post("/orari/", json=shift, headers=headers)
+
+    gcal_events = [
+        {
+            "id": "ev123",
+            "titolo": "Turno Ag.Sc. Danesi",
+            "descrizione": "",
+            "data_ora": datetime(2023, 1, 2, 8, 0),
+        }
+    ]
+
+    captured = {}
+    real_df_to_pdf = __import__("app.services.excel_import", fromlist=["df_to_pdf"]).df_to_pdf
+
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
+
+    def capture_df_to_pdf(rows, db):
+        pdf_path, html_path = real_df_to_pdf(rows, db)
+        captured["html_text"] = Path(html_path).read_text()
+        return pdf_path, html_path
+
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        with patch("app.services.google_calendar.list_events_between", lambda s, e: gcal_events):
+            with patch("app.routes.orari.df_to_pdf", side_effect=capture_df_to_pdf):
+                res = client.get("/orari/pdf?week=2023-W01", headers=headers)
+
+    assert res.status_code == 200
+    assert "Turno Ag.Sc. Danesi" not in captured["html_text"]
+
+
 def test_week_pdf_ignores_empty_gcal_titles(setup_db, tmp_path):
     headers, user_id = auth_user("gcalnone@example.com")
 


### PR DESCRIPTION
## Summary
- skip Google Calendar events whose titles start with `turno`
- add regression test that ensures events titled "Turno Ag.Sc. Danesi" are omitted

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `./scripts/test.sh` *(fails to install dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68715c91bd548323b3ac20ec76221127