### PR TITLE
Include colorId when listing events

### DIFF
--- a/app/services/google_calendar.py
+++ b/app/services/google_calendar.py
@@ -71,6 +71,7 @@ def list_upcoming_events(days: int) -> list[dict[str, Any]]:
                     "titolo": ev.get("summary"),
                     "descrizione": ev.get("description"),
                     "data_ora": dt,
+                    "colorId": ev.get("colorId"),
                 }
             )
         return items
@@ -143,6 +144,7 @@ def list_events_between(start: datetime, end: datetime) -> list[dict[str, Any]]:
                     "titolo": ev.get("summary"),
                     "descrizione": ev.get("description"),
                     "data_ora": dt,
+                    "colorId": ev.get("colorId"),
                 }
             )
         return items

--- a/tests/test_google_calendar_module.py
+++ b/tests/test_google_calendar_module.py
@@ -36,12 +36,14 @@ def test_list_events_between_success(monkeypatch):
                                 "summary": "A",
                                 "description": "desc",
                                 "start": {"dateTime": "2023-01-02T10:00:00Z"},
+                                "colorId": "1",
                             },
                             {
                                 "id": "2",
                                 "summary": "B",
                                 "description": "",
                                 "start": {"date": "2023-01-03"},
+                                "colorId": "2",
                             },
                         ]
                     }
@@ -66,6 +68,8 @@ def test_list_events_between_success(monkeypatch):
     assert result[0]["id"] == "1"
     assert isinstance(result[0]["data_ora"], datetime)
     assert result[1]["data_ora"].date() == datetime(2023, 1, 3).date()
+    assert result[0]["colorId"] == "1"
+    assert result[1]["colorId"] == "2"
 
 
 def test_list_events_between_missing_config(monkeypatch):


### PR DESCRIPTION
## Summary
- add `colorId` field to the output of `list_upcoming_events` and `list_events_between`
- test the new field in `test_google_calendar_module`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68715fbdf1308323abeafb514bad6de1