### PR TITLE
Validate G_SHIFT_CAL_ID format

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import os
+import re
 
 
 @dataclass
@@ -17,6 +18,9 @@ class Settings:
     LOG_LEVEL: str = "INFO"
 
 
+_CAL_ID_RE = re.compile(r"^[A-Za-z0-9_-]+@group\.calendar\.google\.com$")
+
+
 def load_settings() -> Settings:
     missing = []
     database_url = os.getenv("DATABASE_URL")
@@ -30,6 +34,10 @@ def load_settings() -> Settings:
             "Missing required environment variables: " + ", ".join(missing)
         )
 
+    g_shift_cal_id = os.getenv("G_SHIFT_CAL_ID")
+    if g_shift_cal_id and not _CAL_ID_RE.fullmatch(g_shift_cal_id):
+        raise RuntimeError("Invalid G_SHIFT_CAL_ID format")
+
     return Settings(
         DATABASE_URL=database_url,
         SECRET_KEY=secret_key,
@@ -37,7 +45,7 @@ def load_settings() -> Settings:
         ACCESS_TOKEN_EXPIRE_MINUTES=int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30")),
         PDF_UPLOAD_ROOT=os.getenv("PDF_UPLOAD_ROOT", "uploads/pdfs"),
         GOOGLE_CREDENTIALS_JSON=os.getenv("GOOGLE_CREDENTIALS_JSON"),
-        G_SHIFT_CAL_ID=os.getenv("G_SHIFT_CAL_ID"),
+        G_SHIFT_CAL_ID=g_shift_cal_id,
         GOOGLE_CALENDAR_ID=os.getenv("GOOGLE_CALENDAR_ID"),
         GOOGLE_CLIENT_ID=os.getenv("GOOGLE_CLIENT_ID"),
         CORS_ORIGINS=os.getenv("CORS_ORIGINS", "*"),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,4 +3,6 @@ import os
 # Ensure a default secret key is available for tests
 os.environ.setdefault("SECRET_KEY", "test-secret-key")
 os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client")
-os.environ.setdefault("G_SHIFT_CAL_ID", "test-shift-cal")
+os.environ.setdefault(
+    "G_SHIFT_CAL_ID", "test-shift-cal@group.calendar.google.com"
+)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,16 @@
+import pytest
+from app import config
+
+
+def test_load_settings_rejects_bad_calendar_id(monkeypatch):
+    monkeypatch.setenv("G_SHIFT_CAL_ID", "bad")
+    with pytest.raises(RuntimeError, match="G_SHIFT_CAL_ID"):
+        config.load_settings()
+
+
+def test_load_settings_accepts_valid_calendar_id(monkeypatch):
+    good = "ok123@group.calendar.google.com"
+    monkeypatch.setenv("G_SHIFT_CAL_ID", good)
+    settings = config.load_settings()
+    assert settings.G_SHIFT_CAL_ID == good
+


### PR DESCRIPTION
## Summary
- validate `G_SHIFT_CAL_ID` in `load_settings`
- update default test calendar ID
- add tests for calendar ID validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687163197c288323b887df5a2c76c8a3