### PR TITLE
Add calendar event sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ If asynchronous database access becomes necessary later on, add `asyncpg` to
 - `ALGORITHM` – (optional) algorithm used for JWT; defaults to `HS256`.
 - `ACCESS_TOKEN_EXPIRE_MINUTES` – (optional) lifetime of access tokens in minutes; defaults to `30`.
 - `PDF_UPLOAD_ROOT` – directory where uploaded PDF files are stored.
-- `GOOGLE_CREDENTIALS_JSON` – JSON credentials (or path) for Google APIs.
-- `GOOGLE_CALENDAR_ID` – ID of the calendar to read events from.
+- `GOOGLE_CREDENTIALS_JSON` – JSON credentials (or path) for Google APIs. The
+  credentials must allow Calendar read/write access.
+- `GOOGLE_CALENDAR_ID` – ID of the calendar used to read **and create** events.
 - `G_SHIFT_CAL_ID` – ID of the Google Calendar used for shift syncs. Colors for
   shift events are assigned per agent using the `AGENT_COLORS` mapping defined
   in `app/services/gcal.py`. Agents not listed there fall back to a

--- a/app/services/calendar_events.py
+++ b/app/services/calendar_events.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import timedelta
+
+from googleapiclient.discovery import build  # type: ignore
+from google.oauth2.service_account import Credentials as SACredentials  # type: ignore
+from google.oauth2.credentials import Credentials as UserCredentials  # type: ignore
+
+from app.config import settings
+from app.models.event import Event
+
+logger = logging.getLogger(__name__)
+
+
+def create_event(event: Event) -> None:
+    """Insert ``event`` into Google Calendar if configuration is present."""
+    creds_json = settings.GOOGLE_CREDENTIALS_JSON
+    calendar_id = settings.GOOGLE_CALENDAR_ID
+    if not creds_json or not calendar_id:
+        return
+
+    if os.path.isfile(creds_json):
+        with open(creds_json, "r") as fh:
+            info = json.load(fh)
+    else:
+        info = json.loads(creds_json)
+
+    if info.get("type") == "service_account":
+        creds = SACredentials.from_service_account_info(
+            info, scopes=["https://www.googleapis.com/auth/calendar"]
+        )
+    else:
+        creds = UserCredentials.from_authorized_user_info(info)
+
+    service = build("calendar", "v3", credentials=creds)
+
+    body = {
+        "summary": event.titolo,
+        "description": event.descrizione,
+        "start": {"dateTime": event.data_ora.isoformat()},
+        "end": {"dateTime": (event.data_ora + timedelta(hours=1)).isoformat()},
+    }
+
+    try:
+        service.events().insert(calendarId=calendar_id, body=body).execute()
+        logger.info("Inserted event %s into calendar %s", event.id, calendar_id)
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        logger.error(
+            "Failed to create Google Calendar event (cal_id=%s): %s",
+            calendar_id,
+            exc,
+        )
+        raise


### PR DESCRIPTION
## Summary
- add `app/services/calendar_events.py` with Google Calendar helper
- call the helper when creating events
- document calendar environment variables
- test Google Calendar integration on event creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6871735672a48323b176f8c130fa1843