### PR TITLE
Add sendUpdates to calendar update calls

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -190,6 +190,7 @@ def sync_shift_event(turno):
             calendarId=cal_id,
             eventId=evt_id,
             body=body,
+            sendUpdates="none",
         ).execute()
         logger.info("Updated event %s", evt_id)
     except gerr.HttpError as e:


### PR DESCRIPTION
## Summary
- specify `sendUpdates="none"` on shift event updates
- check for the new parameter in calendar tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687173582e208323955c38d918ae5866