### PR TITLE
Cache Google Calendar client

### DIFF
--- a/tests/test_google_calendar_module.py
+++ b/tests/test_google_calendar_module.py
@@ -8,6 +8,7 @@ from app.services import google_calendar
 
 
 def test_list_events_between_success(monkeypatch):
+    google_calendar.get_service.cache_clear()
     dummy_info = {"type": "service_account"}
     monkeypatch.setattr(google_calendar.settings, "GOOGLE_CREDENTIALS_JSON", json.dumps(dummy_info))
     monkeypatch.setattr(google_calendar.settings, "GOOGLE_CALENDAR_ID", "CAL")
@@ -73,6 +74,7 @@ def test_list_events_between_success(monkeypatch):
 
 
 def test_list_events_between_missing_config(monkeypatch):
+    google_calendar.get_service.cache_clear()
     monkeypatch.setattr(google_calendar.settings, "GOOGLE_CREDENTIALS_JSON", None)
     monkeypatch.setattr(google_calendar.settings, "GOOGLE_CALENDAR_ID", None)
 


### PR DESCRIPTION
## Summary
- add a cached `get_service` helper for Google Calendar API
- use `get_service` in upcoming and between event queries
- clear Google Calendar service cache in unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68717359fb1c8323830cff0a1a33c6de