### PR TITLE
Ensure calendar updates skip notifications

### DIFF
--- a/app/services/gcal.py
+++ b/app/services/gcal.py
@@ -22,6 +22,10 @@ from app.schemas.turno import DAY_OFF_TYPES, TipoTurno
 
 logger = logging.getLogger(__name__)
 
+# Default behaviour is to avoid sending email notifications when calendar
+# events are modified.
+DEFAULT_SEND_UPDATES = "none"
+
 # ------------------------------------------------------------------- agent colors
 # Mapping of agent email addresses, IDs or names to Google Calendar color IDs.
 # These values are used by ``color_for_user`` when the matching key is found.
@@ -190,7 +194,7 @@ def sync_shift_event(turno):
             calendarId=cal_id,
             eventId=evt_id,
             body=body,
-            sendUpdates="none",
+            sendUpdates=DEFAULT_SEND_UPDATES,
         ).execute()
         logger.info("Updated event %s", evt_id)
     except gerr.HttpError as e:
@@ -207,7 +211,7 @@ def sync_shift_event(turno):
                 gcal.events().insert(
                     calendarId=cal_id,
                     body=body,
-                    sendUpdates="none",
+                    sendUpdates=DEFAULT_SEND_UPDATES,
                 ).execute()
                 logger.info("Inserted event %s", evt_id)
             except gerr.HttpError as e2:
@@ -236,7 +240,7 @@ def delete_shift_event(turno_id):
         gcal.events().delete(
             calendarId=cal_id,
             eventId=shift_event_id(turno_id),
-            sendUpdates="none",
+            sendUpdates=DEFAULT_SEND_UPDATES,
         ).execute()
         logger.info("Deleted event %s", turno_id)
     except gerr.HttpError as e:

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -137,7 +137,7 @@ def test_sync_shift_event_insert_on_bad_event_id(monkeypatch):
 
     assert update_called.get("called") is True
     assert insert_called.get("called") is True
-    assert update_called["kwargs"].get("sendUpdates") == "none"
+    assert update_called["kwargs"].get("sendUpdates") == gcal.DEFAULT_SEND_UPDATES
 
 
 def test_sync_shift_event_sets_color_from_user(monkeypatch):
@@ -180,7 +180,7 @@ def test_sync_shift_event_sets_color_from_user(monkeypatch):
     gcal.sync_shift_event(turno)
 
     assert captured["color"] == gcal.color_for_user(user)
-    assert captured["sendUpdates"] == "none"
+    assert captured["sendUpdates"] == gcal.DEFAULT_SEND_UPDATES
 
 
 @pytest.mark.parametrize(
@@ -285,7 +285,7 @@ def test_sync_shift_event_logs_info_on_update_404(monkeypatch, caplog):
 
     assert insert_called.get("called") is True
     assert "Update of event" in caplog.text
-    assert update_kwargs.get("sendUpdates") == "none"
+    assert update_kwargs.get("sendUpdates") == gcal.DEFAULT_SEND_UPDATES
 
 
 def test_sync_shift_event_update_error_reraised(monkeypatch, caplog):
@@ -316,7 +316,7 @@ def test_sync_shift_event_update_error_reraised(monkeypatch, caplog):
             gcal.sync_shift_event(turno)
 
     assert "Failed to update event" in caplog.text
-    assert update_kwargs.get("sendUpdates") == "none"
+    assert update_kwargs.get("sendUpdates") == gcal.DEFAULT_SEND_UPDATES
 
 
 def test_sync_shift_event_insert_failure_reraised(monkeypatch, caplog):
@@ -354,7 +354,7 @@ def test_sync_shift_event_insert_failure_reraised(monkeypatch, caplog):
             gcal.sync_shift_event(turno)
 
     assert "Failed to insert event" in caplog.text
-    assert update_kwargs.get("sendUpdates") == "none"
+    assert update_kwargs.get("sendUpdates") == gcal.DEFAULT_SEND_UPDATES
 
 
 def test_delete_shift_event_logs_info_on_404(monkeypatch, caplog):
@@ -432,7 +432,7 @@ def test_sync_shift_event_logs_info_on_update_success(monkeypatch, caplog):
         gcal.sync_shift_event(turno)
 
     assert "Updated event" in caplog.text
-    assert update_kwargs.get("sendUpdates") == "none"
+    assert update_kwargs.get("sendUpdates") == gcal.DEFAULT_SEND_UPDATES
 
 
 def test_sync_shift_event_logs_info_on_insert_success(monkeypatch, caplog):
@@ -469,7 +469,7 @@ def test_sync_shift_event_logs_info_on_insert_success(monkeypatch, caplog):
         gcal.sync_shift_event(turno)
 
     assert "Inserted event" in caplog.text
-    assert update_kwargs.get("sendUpdates") == "none"
+    assert update_kwargs.get("sendUpdates") == gcal.DEFAULT_SEND_UPDATES
 
 
 def test_delete_shift_event_logs_info_on_success(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- use a constant for the `sendUpdates` value in Google Calendar operations
- update tests to check against the constant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68740581fd788323846cc07d6378e8ab