### PR TITLE
Add road signage models and APIs

### DIFF
--- a/app/crud/dispositivo.py
+++ b/app/crud/dispositivo.py
@@ -1,0 +1,38 @@
+from sqlalchemy.orm import Session
+from app.models.dispositivo import Dispositivo
+
+
+def create_dispositivo(db: Session, data):
+    db_obj = Dispositivo(**data.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_dispositivi(db: Session, search: str | None = None, anno: int | None = None):
+    query = db.query(Dispositivo)
+    if search:
+        query = query.filter(Dispositivo.nome.ilike(f"%{search}%"))
+    if anno is not None:
+        query = query.filter(Dispositivo.anno == anno)
+    return query.all()
+
+
+def update_dispositivo(db: Session, dispositivo_id: str, data):
+    db_obj = db.query(Dispositivo).filter(Dispositivo.id == dispositivo_id).first()
+    if not db_obj:
+        return None
+    for key, value in data.dict().items():
+        setattr(db_obj, key, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def delete_dispositivo(db: Session, dispositivo_id: str):
+    db_obj = db.query(Dispositivo).filter(Dispositivo.id == dispositivo_id).first()
+    if db_obj:
+        db.delete(db_obj)
+        db.commit()
+    return db_obj

--- a/app/crud/piano_segnaletica_orizzontale.py
+++ b/app/crud/piano_segnaletica_orizzontale.py
@@ -1,0 +1,60 @@
+from sqlalchemy.orm import Session
+from app.models.piano_segnaletica_orizzontale import (
+    PianoSegnaleticaOrizzontale,
+    SegnaleticaOrizzontaleItem,
+)
+
+
+def create_piano(db: Session, data):
+    db_obj = PianoSegnaleticaOrizzontale(**data.dict(exclude={"items"}))
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_piani(db: Session, search: str | None = None, anno: int | None = None):
+    query = db.query(PianoSegnaleticaOrizzontale)
+    if search:
+        query = query.filter(PianoSegnaleticaOrizzontale.descrizione.ilike(f"%{search}%"))
+    if anno is not None:
+        query = query.filter(PianoSegnaleticaOrizzontale.anno == anno)
+    return query.all()
+
+
+def update_piano(db: Session, piano_id: str, data):
+    db_obj = db.query(PianoSegnaleticaOrizzontale).filter(PianoSegnaleticaOrizzontale.id == piano_id).first()
+    if not db_obj:
+        return None
+    for key, value in data.dict(exclude_unset=True).items():
+        setattr(db_obj, key, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def delete_piano(db: Session, piano_id: str):
+    db_obj = db.query(PianoSegnaleticaOrizzontale).filter(PianoSegnaleticaOrizzontale.id == piano_id).first()
+    if db_obj:
+        db.delete(db_obj)
+        db.commit()
+    return db_obj
+
+
+def add_item(db: Session, piano_id: str, data):
+    db_piano = db.query(PianoSegnaleticaOrizzontale).filter(PianoSegnaleticaOrizzontale.id == piano_id).first()
+    if not db_piano:
+        return None
+    item = SegnaleticaOrizzontaleItem(**data.dict(), piano_id=piano_id)
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+def delete_item(db: Session, item_id: str):
+    db_obj = db.query(SegnaleticaOrizzontaleItem).filter(SegnaleticaOrizzontaleItem.id == item_id).first()
+    if db_obj:
+        db.delete(db_obj)
+        db.commit()
+    return db_obj

--- a/app/crud/segnaletica_temporanea.py
+++ b/app/crud/segnaletica_temporanea.py
@@ -1,0 +1,38 @@
+from sqlalchemy.orm import Session
+from app.models.segnaletica_temporanea import SegnaleticaTemporanea
+
+
+def create_segnaletica_temporanea(db: Session, data):
+    db_obj = SegnaleticaTemporanea(**data.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_segnaletica_temporanea(db: Session, search: str | None = None, anno: int | None = None):
+    query = db.query(SegnaleticaTemporanea)
+    if search:
+        query = query.filter(SegnaleticaTemporanea.descrizione.ilike(f"%{search}%"))
+    if anno is not None:
+        query = query.filter(SegnaleticaTemporanea.anno == anno)
+    return query.all()
+
+
+def update_segnaletica_temporanea(db: Session, st_id: str, data):
+    db_obj = db.query(SegnaleticaTemporanea).filter(SegnaleticaTemporanea.id == st_id).first()
+    if not db_obj:
+        return None
+    for key, value in data.dict().items():
+        setattr(db_obj, key, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def delete_segnaletica_temporanea(db: Session, st_id: str):
+    db_obj = db.query(SegnaleticaTemporanea).filter(SegnaleticaTemporanea.id == st_id).first()
+    if db_obj:
+        db.delete(db_obj)
+        db.commit()
+    return db_obj

--- a/app/crud/segnaletica_verticale.py
+++ b/app/crud/segnaletica_verticale.py
@@ -1,0 +1,38 @@
+from sqlalchemy.orm import Session
+from app.models.segnaletica_verticale import SegnaleticaVerticale
+
+
+def create_segnaletica_verticale(db: Session, data):
+    db_obj = SegnaleticaVerticale(**data.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_segnaletica_verticale(db: Session, search: str | None = None, anno: int | None = None):
+    query = db.query(SegnaleticaVerticale)
+    if search:
+        query = query.filter(SegnaleticaVerticale.descrizione.ilike(f"%{search}%"))
+    if anno is not None:
+        query = query.filter(SegnaleticaVerticale.anno == anno)
+    return query.all()
+
+
+def update_segnaletica_verticale(db: Session, sv_id: str, data):
+    db_obj = db.query(SegnaleticaVerticale).filter(SegnaleticaVerticale.id == sv_id).first()
+    if not db_obj:
+        return None
+    for key, value in data.dict().items():
+        setattr(db_obj, key, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def delete_segnaletica_verticale(db: Session, sv_id: str):
+    db_obj = db.query(SegnaleticaVerticale).filter(SegnaleticaVerticale.id == sv_id).first()
+    if db_obj:
+        db.delete(db_obj)
+        db.commit()
+    return db_obj

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,10 @@ from app.routes import (
     pdf_files,
     dashboard,
     health,
+    dispositivi,
+    segnaletica_temporanea,
+    segnaletica_verticale,
+    piani_orizzontali,
 )
 from app.routes.orari import router as orari_router
 from app.routes import imports
@@ -45,6 +49,10 @@ app.include_router(events.router)
 app.include_router(todo.router)
 app.include_router(determinazioni.router)
 app.include_router(pdf_files.router)
+app.include_router(dispositivi.router)
+app.include_router(segnaletica_temporanea.router)
+app.include_router(segnaletica_verticale.router)
+app.include_router(piani_orizzontali.router)
 app.include_router(dashboard.router)
 app.include_router(health.router)
 app.include_router(orari_router)

--- a/app/models/dispositivo.py
+++ b/app/models/dispositivo.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, String, Integer
+from app.database import Base
+import uuid
+
+
+class Dispositivo(Base):
+    __tablename__ = "dispositivi"
+
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
+    nome = Column(String, nullable=False)
+    descrizione = Column(String, nullable=True)
+    anno = Column(Integer, nullable=True)

--- a/app/models/piano_segnaletica_orizzontale.py
+++ b/app/models/piano_segnaletica_orizzontale.py
@@ -1,0 +1,29 @@
+from sqlalchemy import Column, String, Integer, ForeignKey
+from sqlalchemy.orm import relationship
+from app.database import Base
+import uuid
+
+
+class PianoSegnaleticaOrizzontale(Base):
+    __tablename__ = "piani_segnaletica_orizzontale"
+
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
+    descrizione = Column(String, nullable=False)
+    anno = Column(Integer, nullable=True)
+
+    items = relationship(
+        "SegnaleticaOrizzontaleItem",
+        back_populates="piano",
+        cascade="all, delete-orphan",
+    )
+
+
+class SegnaleticaOrizzontaleItem(Base):
+    __tablename__ = "segnaletica_orizzontale_items"
+
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
+    piano_id = Column(String, ForeignKey("piani_segnaletica_orizzontale.id"), nullable=False)
+    descrizione = Column(String, nullable=False)
+    quantita = Column(Integer, nullable=False, default=1)
+
+    piano = relationship("PianoSegnaleticaOrizzontale", back_populates="items")

--- a/app/models/segnaletica_temporanea.py
+++ b/app/models/segnaletica_temporanea.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, String, Integer
+from app.database import Base
+import uuid
+
+
+class SegnaleticaTemporanea(Base):
+    __tablename__ = "segnaletica_temporanea"
+
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
+    descrizione = Column(String, nullable=False)
+    anno = Column(Integer, nullable=True)

--- a/app/models/segnaletica_verticale.py
+++ b/app/models/segnaletica_verticale.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, String, Integer
+from app.database import Base
+import uuid
+
+
+class SegnaleticaVerticale(Base):
+    __tablename__ = "segnaletica_verticale"
+
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
+    descrizione = Column(String, nullable=False)
+    anno = Column(Integer, nullable=True)

--- a/app/routes/dispositivi.py
+++ b/app/routes/dispositivi.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.dependencies import get_db
+from app.schemas.dispositivo import DispositivoCreate, DispositivoResponse
+from app.crud import dispositivo
+
+router = APIRouter(prefix="/dispositivi", tags=["Dispositivi"])
+
+
+@router.post("/", response_model=DispositivoResponse)
+def create_dispositivo_route(data: DispositivoCreate, db: Session = Depends(get_db)):
+    return dispositivo.create_dispositivo(db, data)
+
+
+@router.get("/", response_model=list[DispositivoResponse])
+def list_dispositivi(
+    search: str | None = None,
+    anno: int | None = None,
+    db: Session = Depends(get_db),
+):
+    return dispositivo.get_dispositivi(db, search=search, anno=anno)
+
+
+@router.put("/{dispositivo_id}", response_model=DispositivoResponse)
+def update_dispositivo_route(dispositivo_id: str, data: DispositivoCreate, db: Session = Depends(get_db)):
+    db_obj = dispositivo.update_dispositivo(db, dispositivo_id, data)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Dispositivo not found")
+    return db_obj
+
+
+@router.delete("/{dispositivo_id}")
+def delete_dispositivo_route(dispositivo_id: str, db: Session = Depends(get_db)):
+    db_obj = dispositivo.delete_dispositivo(db, dispositivo_id)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Dispositivo not found")
+    return {"ok": True}

--- a/app/routes/piani_orizzontali.py
+++ b/app/routes/piani_orizzontali.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.dependencies import get_db
+from app.schemas.piano_segnaletica_orizzontale import (
+    PianoSegnaleticaOrizzontaleCreate,
+    PianoSegnaleticaOrizzontaleResponse,
+    SegnaleticaOrizzontaleItemCreate,
+    SegnaleticaOrizzontaleItemResponse,
+)
+from app.crud import piano_segnaletica_orizzontale as crud
+
+router = APIRouter(prefix="/piani-orizzontali", tags=["Piani Segnaletica Orizzontale"])
+
+
+@router.post("/", response_model=PianoSegnaleticaOrizzontaleResponse)
+def create_piano_route(data: PianoSegnaleticaOrizzontaleCreate, db: Session = Depends(get_db)):
+    return crud.create_piano(db, data)
+
+
+@router.get("/", response_model=list[PianoSegnaleticaOrizzontaleResponse])
+def list_piani(
+    search: str | None = None,
+    anno: int | None = None,
+    db: Session = Depends(get_db),
+):
+    return crud.get_piani(db, search=search, anno=anno)
+
+
+@router.put("/{piano_id}", response_model=PianoSegnaleticaOrizzontaleResponse)
+def update_piano_route(
+    piano_id: str,
+    data: PianoSegnaleticaOrizzontaleCreate,
+    db: Session = Depends(get_db),
+):
+    db_obj = crud.update_piano(db, piano_id, data)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Piano not found")
+    return db_obj
+
+
+@router.delete("/{piano_id}")
+def delete_piano_route(piano_id: str, db: Session = Depends(get_db)):
+    db_obj = crud.delete_piano(db, piano_id)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Piano not found")
+    return {"ok": True}
+
+
+@router.post("/{piano_id}/items", response_model=SegnaleticaOrizzontaleItemResponse)
+def add_item_route(
+    piano_id: str,
+    data: SegnaleticaOrizzontaleItemCreate,
+    db: Session = Depends(get_db),
+):
+    item = crud.add_item(db, piano_id, data)
+    if not item:
+        raise HTTPException(status_code=404, detail="Piano not found")
+    return item
+
+
+@router.delete("/items/{item_id}")
+def delete_item_route(item_id: str, db: Session = Depends(get_db)):
+    item = crud.delete_item(db, item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return {"ok": True}

--- a/app/routes/segnaletica_temporanea.py
+++ b/app/routes/segnaletica_temporanea.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.dependencies import get_db
+from app.schemas.segnaletica_temporanea import (
+    SegnaleticaTemporaneaCreate,
+    SegnaleticaTemporaneaResponse,
+)
+from app.crud import segnaletica_temporanea as crud
+
+router = APIRouter(prefix="/segnaletica-temporanea", tags=["Segnaletica Temporanea"])
+
+
+@router.post("/", response_model=SegnaleticaTemporaneaResponse)
+def create_segnaletica_temporanea_route(
+    data: SegnaleticaTemporaneaCreate, db: Session = Depends(get_db)
+):
+    return crud.create_segnaletica_temporanea(db, data)
+
+
+@router.get("/", response_model=list[SegnaleticaTemporaneaResponse])
+def list_segnaletica_temporanea(
+    search: str | None = None,
+    anno: int | None = None,
+    db: Session = Depends(get_db),
+):
+    return crud.get_segnaletica_temporanea(db, search=search, anno=anno)
+
+
+@router.put("/{st_id}", response_model=SegnaleticaTemporaneaResponse)
+def update_segnaletica_temporanea_route(
+    st_id: str, data: SegnaleticaTemporaneaCreate, db: Session = Depends(get_db)
+):
+    db_obj = crud.update_segnaletica_temporanea(db, st_id, data)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnaletica temporanea not found")
+    return db_obj
+
+
+@router.delete("/{st_id}")
+def delete_segnaletica_temporanea_route(st_id: str, db: Session = Depends(get_db)):
+    db_obj = crud.delete_segnaletica_temporanea(db, st_id)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnaletica temporanea not found")
+    return {"ok": True}

--- a/app/routes/segnaletica_verticale.py
+++ b/app/routes/segnaletica_verticale.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.dependencies import get_db
+from app.schemas.segnaletica_verticale import (
+    SegnaleticaVerticaleCreate,
+    SegnaleticaVerticaleResponse,
+)
+from app.crud import segnaletica_verticale as crud
+
+router = APIRouter(prefix="/segnaletica-verticale", tags=["Segnaletica Verticale"])
+
+
+@router.post("/", response_model=SegnaleticaVerticaleResponse)
+def create_segnaletica_verticale_route(
+    data: SegnaleticaVerticaleCreate, db: Session = Depends(get_db)
+):
+    return crud.create_segnaletica_verticale(db, data)
+
+
+@router.get("/", response_model=list[SegnaleticaVerticaleResponse])
+def list_segnaletica_verticale(
+    search: str | None = None,
+    anno: int | None = None,
+    db: Session = Depends(get_db),
+):
+    return crud.get_segnaletica_verticale(db, search=search, anno=anno)
+
+
+@router.put("/{sv_id}", response_model=SegnaleticaVerticaleResponse)
+def update_segnaletica_verticale_route(
+    sv_id: str, data: SegnaleticaVerticaleCreate, db: Session = Depends(get_db)
+):
+    db_obj = crud.update_segnaletica_verticale(db, sv_id, data)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnaletica verticale not found")
+    return db_obj
+
+
+@router.delete("/{sv_id}")
+def delete_segnaletica_verticale_route(sv_id: str, db: Session = Depends(get_db)):
+    db_obj = crud.delete_segnaletica_verticale(db, sv_id)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnaletica verticale not found")
+    return {"ok": True}

--- a/app/schemas/dispositivo.py
+++ b/app/schemas/dispositivo.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+
+class DispositivoCreate(BaseModel):
+    nome: str
+    descrizione: str | None = None
+    anno: int | None = None
+
+
+class DispositivoResponse(DispositivoCreate):
+    id: str
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/schemas/piano_segnaletica_orizzontale.py
+++ b/app/schemas/piano_segnaletica_orizzontale.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class SegnaleticaOrizzontaleItemCreate(BaseModel):
+    descrizione: str
+    quantita: int = 1
+
+
+class SegnaleticaOrizzontaleItemResponse(SegnaleticaOrizzontaleItemCreate):
+    id: str
+    piano_id: str
+
+    model_config = {
+        "from_attributes": True,
+    }
+
+
+class PianoSegnaleticaOrizzontaleCreate(BaseModel):
+    descrizione: str
+    anno: int | None = None
+
+
+class PianoSegnaleticaOrizzontaleResponse(PianoSegnaleticaOrizzontaleCreate):
+    id: str
+    items: List[SegnaleticaOrizzontaleItemResponse] = []
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/schemas/segnaletica_temporanea.py
+++ b/app/schemas/segnaletica_temporanea.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class SegnaleticaTemporaneaCreate(BaseModel):
+    descrizione: str
+    anno: int | None = None
+
+
+class SegnaleticaTemporaneaResponse(SegnaleticaTemporaneaCreate):
+    id: str
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/schemas/segnaletica_verticale.py
+++ b/app/schemas/segnaletica_verticale.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class SegnaleticaVerticaleCreate(BaseModel):
+    descrizione: str
+    anno: int | None = None
+
+
+class SegnaleticaVerticaleResponse(SegnaleticaVerticaleCreate):
+    id: str
+
+    model_config = {
+        "from_attributes": True,
+    }


### PR DESCRIPTION
## Summary
- create tables for new signage-related models
- add Pydantic schemas for new tables
- implement CRUD helpers and FastAPI routers
- expose query filters for list endpoints
- register the new routers in `app/main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6876765edcf48323ad213931175e408a