### PR TITLE
Add inventory PDF generation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.routes import (
     health,
 )
 from app.routes.orari import router as orari_router
+from app.routes import inventory
 from app.routes import imports
 
 # Enable automatic redirect so both `/path` and `/path/` work
@@ -48,6 +49,7 @@ app.include_router(pdf_files.router)
 app.include_router(dashboard.router)
 app.include_router(health.router)
 app.include_router(orari_router)
+app.include_router(inventory.router)
 app.include_router(imports.router)
 
 from app.crud.pdf_file import get_upload_root

--- a/app/routes/inventory.py
+++ b/app/routes/inventory.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, BackgroundTasks
+from fastapi.responses import FileResponse
+import os
+
+from app.services.inventory_pdf import build_inventory_pdf
+
+router = APIRouter(prefix="/inventory", tags=["Inventory"])
+
+
+@router.get("/pdf")
+def inventory_pdf(year: int, background_tasks: BackgroundTasks):
+    """Return a PDF inventory report for the specified year."""
+    # In a real application this would fetch data from the database.
+    items = []  # placeholder for inventory entries
+    pdf_path, html_path = build_inventory_pdf(items, year)
+    background_tasks.add_task(os.remove, pdf_path)
+    background_tasks.add_task(os.remove, html_path)
+    filename = f"inventory_{year}.pdf"
+    return FileResponse(pdf_path, filename=filename)

--- a/app/services/inventory_pdf.py
+++ b/app/services/inventory_pdf.py
@@ -1,0 +1,38 @@
+from typing import List, Dict, Any, Tuple
+from weasyprint import HTML
+import tempfile
+
+
+def build_inventory_pdf(items: List[Dict[str, Any]], year: int) -> Tuple[str, str]:
+    """Generate an inventory PDF for *year* from ``items``.
+
+    Each item should be a mapping with ``name`` and ``count`` keys. The
+    function returns a tuple ``(pdf_path, html_path)`` with the generated
+    files.
+    """
+
+    rows_html = "".join(
+        f"<tr><td>{item.get('name', '')}</td><td>{item.get('count', '')}</td></tr>"
+        for item in items
+    )
+
+    html_content = f"""
+    <html>
+    <body>
+    <h1>Inventario {year}</h1>
+    <table border='1' style='border-collapse:collapse;'>
+        <tr><th>Nome</th><th>Quantità</th></tr>
+        {rows_html}
+    </table>
+    </body>
+    </html>
+    """
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as tmp_html:
+        tmp_html.write(html_content.encode("utf-8"))
+        html_path = tmp_html.name
+
+    pdf_path = html_path.replace(".html", ".pdf")
+    HTML(filename=html_path).write_pdf(pdf_path)
+
+    return pdf_path, html_path


### PR DESCRIPTION
## Summary
- add `inventory_pdf` service for basic PDF creation
- create `inventory` router with `/pdf` endpoint
- include inventory router in app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6876766010208323a35ecef93cf24277