### PR TITLE
Add note field to dispositivi

### DIFF
--- a/app/models/dispositivo.py
+++ b/app/models/dispositivo.py
@@ -10,3 +10,4 @@ class Dispositivo(Base):
     nome = Column(String, nullable=False)
     descrizione = Column(String, nullable=True)
     anno = Column(Integer, nullable=True)
+    note = Column(String, nullable=True)

--- a/app/schemas/dispositivo.py
+++ b/app/schemas/dispositivo.py
@@ -5,6 +5,7 @@ class DispositivoCreate(BaseModel):
     nome: str
     descrizione: str | None = None
     anno: int | None = None
+    note: str | None = None
 
 
 class DispositivoResponse(DispositivoCreate):

--- a/migrations/versions/0006_add_note_to_dispositivo.py
+++ b/migrations/versions/0006_add_note_to_dispositivo.py
@@ -1,0 +1,19 @@
+"""add note column to dispositivi"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0006_add_note_to_dispositivo"
+down_revision = "0005_optional_times_for_day_off"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("dispositivi") as batch_op:
+        batch_op.add_column(sa.Column("note", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("dispositivi") as batch_op:
+        batch_op.drop_column("note")

--- a/tests/test_dispositivi.py
+++ b/tests/test_dispositivi.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_create_dispositivo_with_note(setup_db):
+    data = {"nome": "Tablet", "descrizione": "iPad", "anno": 2024, "note": "demo"}
+    res = client.post("/dispositivi/", json=data)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["note"] == "demo"
+    assert body["nome"] == "Tablet"
+
+
+def test_list_dispositivi_shows_note(setup_db):
+    client.post(
+        "/dispositivi/",
+        json={"nome": "Phone", "descrizione": "Pixel", "anno": 2023, "note": "abc"},
+    )
+    client.post(
+        "/dispositivi/",
+        json={"nome": "Laptop", "descrizione": "Dell", "anno": 2022, "note": "xyz"},
+    )
+    res = client.get("/dispositivi/")
+    assert res.status_code == 200
+    notes = [d["note"] for d in res.json()]
+    assert "abc" in notes and "xyz" in notes


### PR DESCRIPTION
## Summary
- add a nullable note column to Dispositivo model
- expose new note field via schemas and API
- generate Alembic migration for the new column
- test creating and retrieving dispositivi with notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6879018fdd808323bc5f0b6be6526562