### PR TITLE
Add fields to segnaletica temporanea

### DIFF
--- a/app/models/segnaletica_temporanea.py
+++ b/app/models/segnaletica_temporanea.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Integer
+from sqlalchemy import Column, String, Integer, Date
 from app.database import Base
 import uuid
 
@@ -9,3 +9,6 @@ class SegnaleticaTemporanea(Base):
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
     descrizione = Column(String, nullable=False)
     anno = Column(Integer, nullable=True)
+    luogo = Column(String, nullable=True)
+    fine_validita = Column(Date, nullable=True)
+    quantita = Column(Integer, nullable=True)

--- a/app/schemas/segnaletica_temporanea.py
+++ b/app/schemas/segnaletica_temporanea.py
@@ -1,9 +1,13 @@
 from pydantic import BaseModel
+from datetime import date
 
 
 class SegnaleticaTemporaneaCreate(BaseModel):
     descrizione: str
     anno: int | None = None
+    luogo: str | None = None
+    fine_validita: date | None = None
+    quantita: int | None = None
 
 
 class SegnaleticaTemporaneaResponse(SegnaleticaTemporaneaCreate):

--- a/migrations/versions/0006_add_fields_to_segnaletica_temporanea.py
+++ b/migrations/versions/0006_add_fields_to_segnaletica_temporanea.py
@@ -1,0 +1,23 @@
+"""add luogo fine_validita quantita to segnaletica_temporanea"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0006_add_fields_to_segnaletica_temporanea"
+down_revision = "0005_optional_times_for_day_off"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("segnaletica_temporanea") as batch_op:
+        batch_op.add_column(sa.Column("luogo", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("fine_validita", sa.Date(), nullable=True))
+        batch_op.add_column(sa.Column("quantita", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("segnaletica_temporanea") as batch_op:
+        batch_op.drop_column("quantita")
+        batch_op.drop_column("fine_validita")
+        batch_op.drop_column("luogo")

--- a/tests/test_segnaletica_temporanea.py
+++ b/tests/test_segnaletica_temporanea.py
@@ -1,0 +1,96 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_create_segnaletica_temporanea(setup_db):
+    data = {
+        "descrizione": "Cartello",
+        "anno": 2024,
+        "luogo": "Via Roma",
+        "fine_validita": "2024-06-30",
+        "quantita": 2,
+    }
+    response = client.post("/segnaletica-temporanea/", json=data)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["descrizione"] == "Cartello"
+    assert body["luogo"] == "Via Roma"
+    assert body["fine_validita"] == "2024-06-30"
+    assert body["quantita"] == 2
+    assert "id" in body
+
+
+def test_update_segnaletica_temporanea(setup_db):
+    create = client.post(
+        "/segnaletica-temporanea/",
+        json={
+            "descrizione": "Old",
+            "anno": 2023,
+            "luogo": "Old",
+            "fine_validita": "2023-06-01",
+            "quantita": 1,
+        },
+    )
+    st_id = create.json()["id"]
+    response = client.put(
+        f"/segnaletica-temporanea/{st_id}",
+        json={
+            "descrizione": "New",
+            "anno": 2024,
+            "luogo": "New",
+            "fine_validita": "2024-07-01",
+            "quantita": 5,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["descrizione"] == "New"
+    assert data["luogo"] == "New"
+    assert data["fine_validita"] == "2024-07-01"
+    assert data["quantita"] == 5
+
+
+def test_list_segnaletica_temporanea(setup_db):
+    client.post(
+        "/segnaletica-temporanea/",
+        json={
+            "descrizione": "A",
+            "anno": 2024,
+            "luogo": "A",
+            "fine_validita": "2024-05-01",
+            "quantita": 1,
+        },
+    )
+    client.post(
+        "/segnaletica-temporanea/",
+        json={
+            "descrizione": "B",
+            "anno": 2023,
+            "luogo": "B",
+            "fine_validita": "2023-05-01",
+            "quantita": 2,
+        },
+    )
+    response = client.get("/segnaletica-temporanea/")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test_delete_segnaletica_temporanea(setup_db):
+    res = client.post(
+        "/segnaletica-temporanea/",
+        json={
+            "descrizione": "Del",
+            "anno": 2022,
+            "luogo": "Del",
+            "fine_validita": "2022-05-01",
+            "quantita": 1,
+        },
+    )
+    st_id = res.json()["id"]
+    response = client.delete(f"/segnaletica-temporanea/{st_id}")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert client.get("/segnaletica-temporanea/").json() == []


### PR DESCRIPTION
## Summary
- add luogo, fine_validita and quantita columns to segnaletica temporanea model
- expose new fields via API schemas
- create migration for the new columns
- test CRUD flow for segnaletica temporanea with extra fields

## Testing
- `pytest tests/test_segnaletica_temporanea.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68790194e3e083238ccc1047c0cfc0cc