### PR TITLE
Add fields to segnaletica verticale

### DIFF
--- a/app/models/segnaletica_verticale.py
+++ b/app/models/segnaletica_verticale.py
@@ -8,4 +8,7 @@ class SegnaleticaVerticale(Base):
 
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
     descrizione = Column(String, nullable=False)
+    tipo = Column(String, nullable=True)
+    quantita = Column(Integer, nullable=False, default=1)
+    luogo = Column(String, nullable=True)
     anno = Column(Integer, nullable=True)

--- a/app/schemas/segnaletica_verticale.py
+++ b/app/schemas/segnaletica_verticale.py
@@ -3,6 +3,9 @@ from pydantic import BaseModel
 
 class SegnaleticaVerticaleCreate(BaseModel):
     descrizione: str
+    tipo: str | None = None
+    quantita: int = 1
+    luogo: str | None = None
     anno: int | None = None
 
 

--- a/migrations/versions/0006_add_fields_to_segnaletica_verticale.py
+++ b/migrations/versions/0006_add_fields_to_segnaletica_verticale.py
@@ -1,0 +1,30 @@
+"""add tipo quantita luogo columns"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0006_add_fields_to_segnaletica_verticale"
+down_revision = "0005_optional_times_for_day_off"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "segnaletica_verticale",
+        sa.Column("tipo", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "segnaletica_verticale",
+        sa.Column("quantita", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "segnaletica_verticale",
+        sa.Column("luogo", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("segnaletica_verticale", "luogo")
+    op.drop_column("segnaletica_verticale", "quantita")
+    op.drop_column("segnaletica_verticale", "tipo")

--- a/tests/test_segnaletica_verticale.py
+++ b/tests/test_segnaletica_verticale.py
@@ -1,0 +1,91 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_create_segnaletica_verticale(setup_db):
+    data = {
+        "descrizione": "Cartello stop",
+        "tipo": "Cartello",
+        "quantita": 2,
+        "luogo": "Via Roma",
+        "anno": 2024,
+    }
+    response = client.post("/segnaletica-verticale/", json=data)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["descrizione"] == "Cartello stop"
+    assert body["tipo"] == "Cartello"
+    assert body["quantita"] == 2
+    assert body["luogo"] == "Via Roma"
+    assert body["anno"] == 2024
+    assert "id" in body
+
+
+def test_update_segnaletica_verticale(setup_db):
+    base = {
+        "descrizione": "Segnale",
+        "tipo": "Cartello",
+        "quantita": 1,
+        "luogo": "Piazza",
+        "anno": 2023,
+    }
+    res = client.post("/segnaletica-verticale/", json=base)
+    sv_id = res.json()["id"]
+    base["descrizione"] = "Segnale nuovo"
+    base["quantita"] = 3
+    base["luogo"] = "Centro"
+    update = client.put(f"/segnaletica-verticale/{sv_id}", json=base)
+    assert update.status_code == 200
+    data = update.json()
+    assert data["descrizione"] == "Segnale nuovo"
+    assert data["quantita"] == 3
+    assert data["luogo"] == "Centro"
+
+
+def test_list_segnaletica_verticale(setup_db):
+    client.post(
+        "/segnaletica-verticale/",
+        json={
+            "descrizione": "A",
+            "tipo": "Cartello",
+            "quantita": 1,
+            "luogo": "Via A",
+            "anno": 2023,
+        },
+    )
+    client.post(
+        "/segnaletica-verticale/",
+        json={
+            "descrizione": "B",
+            "tipo": "Cartello",
+            "quantita": 2,
+            "luogo": "Via B",
+            "anno": 2024,
+        },
+    )
+    res = client.get("/segnaletica-verticale/")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 2
+    assert {item["descrizione"] for item in data} == {"A", "B"}
+
+
+def test_delete_segnaletica_verticale(setup_db):
+    res = client.post(
+        "/segnaletica-verticale/",
+        json={
+            "descrizione": "X",
+            "tipo": "Cartello",
+            "quantita": 1,
+            "luogo": "Zona",
+            "anno": 2022,
+        },
+    )
+    sv_id = res.json()["id"]
+    del_res = client.delete(f"/segnaletica-verticale/{sv_id}")
+    assert del_res.status_code == 200
+    assert del_res.json()["ok"] is True
+    assert client.get("/segnaletica-verticale/").json() == []


### PR DESCRIPTION
## Summary
- extend segnaletica verticale model with tipo, quantita and luogo
- expose new fields in the API schema
- migrate existing table with the new columns
- test segnaletica verticale CRUD

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68790196542c8323a4461c7bff78d82e