### PR TITLE
Add inventory tables migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ alembic upgrade head
 
 After pulling the latest changes, run `alembic upgrade head` again to apply the new migration.
 
+The new revision introduces inventory tables (`dispositivi`, `segnaletica_temporanea`, `segnaletica_verticale` and `piani_segnaletica_orizzontale`). Run `alembic upgrade head` so these tables are created.
+
 After modifying the models, create a new revision and upgrade:
 
 ```bash

--- a/migrations/versions/0006_inventory_tables.py
+++ b/migrations/versions/0006_inventory_tables.py
@@ -1,0 +1,88 @@
+"""add inventory tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0006_inventory_tables"
+down_revision = "0005_optional_times_for_day_off"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dispositivi",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("nome", sa.String(), nullable=False),
+        sa.Column("descrizione", sa.String(), nullable=True),
+        sa.Column("anno", sa.Integer(), nullable=True),
+    )
+    op.create_index("ix_dispositivi_id", "dispositivi", ["id"])
+
+    op.create_table(
+        "segnaletica_temporanea",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("descrizione", sa.String(), nullable=False),
+        sa.Column("anno", sa.Integer(), nullable=True),
+    )
+    op.create_index("ix_segnaletica_temporanea_id", "segnaletica_temporanea", ["id"])
+
+    op.create_table(
+        "segnaletica_verticale",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("descrizione", sa.String(), nullable=False),
+        sa.Column("anno", sa.Integer(), nullable=True),
+    )
+    op.create_index("ix_segnaletica_verticale_id", "segnaletica_verticale", ["id"])
+
+    op.create_table(
+        "piani_segnaletica_orizzontale",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("descrizione", sa.String(), nullable=False),
+        sa.Column("anno", sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        "ix_piani_segnaletica_orizzontale_id",
+        "piani_segnaletica_orizzontale",
+        ["id"],
+    )
+
+    op.create_table(
+        "segnaletica_orizzontale_items",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column(
+            "piano_id",
+            sa.String(),
+            sa.ForeignKey("piani_segnaletica_orizzontale.id"),
+            nullable=False,
+        ),
+        sa.Column("descrizione", sa.String(), nullable=False),
+        sa.Column("quantita", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.create_index(
+        "ix_segnaletica_orizzontale_items_id",
+        "segnaletica_orizzontale_items",
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_segnaletica_orizzontale_items_id", table_name="segnaletica_orizzontale_items"
+    )
+    op.drop_table("segnaletica_orizzontale_items")
+
+    op.drop_index(
+        "ix_piani_segnaletica_orizzontale_id", table_name="piani_segnaletica_orizzontale"
+    )
+    op.drop_table("piani_segnaletica_orizzontale")
+
+    op.drop_index("ix_segnaletica_verticale_id", table_name="segnaletica_verticale")
+    op.drop_table("segnaletica_verticale")
+
+    op.drop_index("ix_segnaletica_temporanea_id", table_name="segnaletica_temporanea")
+    op.drop_table("segnaletica_temporanea")
+
+    op.drop_index("ix_dispositivi_id", table_name="dispositivi")
+    op.drop_table("dispositivi")
+


### PR DESCRIPTION
## Summary
- add migration for dispositivi and segnaletica tables
- document running the upgrade to create new tables

## Testing
- `alembic upgrade head` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687901979ecc832396c5a6613e78a9d7