### PR TITLE
Implement update for horizontal signage items

### DIFF
--- a/app/crud/piano_segnaletica_orizzontale.py
+++ b/app/crud/piano_segnaletica_orizzontale.py
@@ -52,6 +52,17 @@ def add_item(db: Session, piano_id: str, data):
     return item
 
 
+def update_item(db: Session, item_id: str, data):
+    db_item = db.query(SegnaleticaOrizzontaleItem).filter(SegnaleticaOrizzontaleItem.id == item_id).first()
+    if not db_item:
+        return None
+    for key, value in data.dict(exclude_unset=True).items():
+        setattr(db_item, key, value)
+    db.commit()
+    db.refresh(db_item)
+    return db_item
+
+
 def delete_item(db: Session, item_id: str):
     db_obj = db.query(SegnaleticaOrizzontaleItem).filter(SegnaleticaOrizzontaleItem.id == item_id).first()
     if db_obj:

--- a/app/routes/piani_orizzontali.py
+++ b/app/routes/piani_orizzontali.py
@@ -6,6 +6,7 @@ from app.schemas.piano_segnaletica_orizzontale import (
     PianoSegnaleticaOrizzontaleResponse,
     SegnaleticaOrizzontaleItemCreate,
     SegnaleticaOrizzontaleItemResponse,
+    SegnaleticaOrizzontaleItemUpdate,
 )
 from app.crud import piano_segnaletica_orizzontale as crud
 
@@ -55,6 +56,18 @@ def add_item_route(
     item = crud.add_item(db, piano_id, data)
     if not item:
         raise HTTPException(status_code=404, detail="Piano not found")
+    return item
+
+
+@router.put("/items/{item_id}", response_model=SegnaleticaOrizzontaleItemResponse)
+def update_item_route(
+    item_id: str,
+    data: SegnaleticaOrizzontaleItemUpdate,
+    db: Session = Depends(get_db),
+):
+    item = crud.update_item(db, item_id, data)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
     return item
 
 

--- a/app/schemas/piano_segnaletica_orizzontale.py
+++ b/app/schemas/piano_segnaletica_orizzontale.py
@@ -7,6 +7,11 @@ class SegnaleticaOrizzontaleItemCreate(BaseModel):
     quantita: int = 1
 
 
+class SegnaleticaOrizzontaleItemUpdate(BaseModel):
+    descrizione: str | None = None
+    quantita: int | None = None
+
+
 class SegnaleticaOrizzontaleItemResponse(SegnaleticaOrizzontaleItemCreate):
     id: str
     piano_id: str

--- a/tests/test_piani_orizzontali.py
+++ b/tests/test_piani_orizzontali.py
@@ -1,0 +1,39 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_update_item(setup_db):
+    # Create piano
+    res = client.post(
+        "/piani-orizzontali/",
+        json={"descrizione": "Piano", "anno": 2024},
+    )
+    piano_id = res.json()["id"]
+
+    # Add item
+    item_res = client.post(
+        f"/piani-orizzontali/{piano_id}/items",
+        json={"descrizione": "Old", "quantita": 1},
+    )
+    item_id = item_res.json()["id"]
+
+    # Update only quantita
+    update_res = client.put(
+        f"/piani-orizzontali/items/{item_id}",
+        json={"quantita": 5},
+    )
+    assert update_res.status_code == 200
+    data = update_res.json()
+    assert data["quantita"] == 5
+    assert data["descrizione"] == "Old"
+
+
+def test_update_item_not_found(setup_db):
+    response = client.put(
+        "/piani-orizzontali/items/unknown",
+        json={"descrizione": "X"},
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- allow partial updates for SegnaleticaOrizzontaleItem via new schema
- add CRUD helper and API route for updating an item
- test updating existing items and the not-found case

## Testing
- `pytest -q tests/test_piani_orizzontali.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6879019cf7f88323bc93ffc7175b299e