### PR TITLE
Implement inventory PDF generation

### DIFF
--- a/app/routes/inventory.py
+++ b/app/routes/inventory.py
@@ -1,6 +1,14 @@
-from fastapi import APIRouter, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, Depends
 from fastapi.responses import FileResponse
 import os
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from app.dependencies import get_db
+from app.models.piano_segnaletica_orizzontale import (
+    PianoSegnaleticaOrizzontale,
+    SegnaleticaOrizzontaleItem,
+)
 
 from app.services.inventory_pdf import build_inventory_pdf
 
@@ -8,10 +16,30 @@ router = APIRouter(prefix="/inventory", tags=["Inventory"])
 
 
 @router.get("/pdf")
-def inventory_pdf(year: int, background_tasks: BackgroundTasks):
+def inventory_pdf(
+    year: int,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
     """Return a PDF inventory report for the specified year."""
-    # In a real application this would fetch data from the database.
-    items = []  # placeholder for inventory entries
+
+    query = (
+        db.query(
+            SegnaleticaOrizzontaleItem.descrizione.label("name"),
+            func.sum(SegnaleticaOrizzontaleItem.quantita).label("count"),
+        )
+        .join(
+            PianoSegnaleticaOrizzontale,
+            SegnaleticaOrizzontaleItem.piano_id == PianoSegnaleticaOrizzontale.id,
+        )
+        .filter(PianoSegnaleticaOrizzontale.anno == year)
+        .group_by(SegnaleticaOrizzontaleItem.descrizione)
+    )
+    items = [
+        {"name": row.name, "count": int(row.count)}
+        for row in query.all()
+    ]
+
     pdf_path, html_path = build_inventory_pdf(items, year)
     background_tasks.add_task(os.remove, pdf_path)
     background_tasks.add_task(os.remove, html_path)

--- a/tests/test_inventory_pdf.py
+++ b/tests/test_inventory_pdf.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_inventory_pdf_from_db(setup_db, tmp_path):
+    # create a plan with items for year 2023
+    res = client.post("/piani-orizzontali/", json={"descrizione": "Piano", "anno": 2023})
+    piano_id = res.json()["id"]
+    client.post(f"/piani-orizzontali/{piano_id}/items", json={"descrizione": "Segnale", "quantita": 2})
+    client.post(f"/piani-orizzontali/{piano_id}/items", json={"descrizione": "Segnale", "quantita": 3})
+    client.post(f"/piani-orizzontali/{piano_id}/items", json={"descrizione": "Altro", "quantita": 1})
+
+    captured = {}
+    real_func = __import__("app.services.inventory_pdf", fromlist=["build_inventory_pdf"]).build_inventory_pdf
+
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
+
+    def capture(items, year):
+        captured["items"] = items
+        pdf_path, html_path = real_func(items, year)
+        captured["html"] = html_path
+        captured["pdf"] = pdf_path
+        captured["html_text"] = Path(html_path).read_text()
+        return pdf_path, html_path
+
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        with patch("app.routes.inventory.build_inventory_pdf", side_effect=capture):
+            res = client.get("/inventory/pdf?year=2023")
+
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "application/pdf"
+    assert sorted(captured["items"], key=lambda x: x["name"]) == [
+        {"name": "Altro", "count": 1},
+        {"name": "Segnale", "count": 5},
+    ]
+    assert "Inventario 2023" in captured["html_text"]


### PR DESCRIPTION
## Summary
- build inventory items from database records
- generate PDF inventory listings by year
- test inventory PDF creation using real data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6879019e69588323ae7063e2cacd3463