### PR TITLE
Add signage horizontal PDF inventory report

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from app.routes import (
 from app.routes.orari import router as orari_router
 from app.routes import inventory
 from app.routes import imports
+from app.routes import inventario
 
 # Enable automatic redirect so both `/path` and `/path/` work
 # Tests continue to use the canonical routes defined in the routers
@@ -59,6 +60,7 @@ app.include_router(health.router)
 app.include_router(orari_router)
 app.include_router(inventory.router)
 app.include_router(imports.router)
+app.include_router(inventario.router)
 
 from app.crud.pdf_file import get_upload_root
 from fastapi.staticfiles import StaticFiles

--- a/app/routes/inventario.py
+++ b/app/routes/inventario.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+import os
+
+from app.dependencies import get_db
+from app.services.signage_horizontal import build_signage_horizontal_pdf
+
+router = APIRouter(prefix="/inventario", tags=["Inventario"])
+
+
+@router.get("/signage-horizontal/pdf")
+def signage_horizontal_pdf(
+    year: int,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
+    pdf_path, html_path = build_signage_horizontal_pdf(db, year)
+    background_tasks.add_task(os.remove, pdf_path)
+    background_tasks.add_task(os.remove, html_path)
+    filename = f"signage_horizontal_{year}.pdf"
+    return FileResponse(pdf_path, filename=filename)

--- a/app/services/signage_horizontal.py
+++ b/app/services/signage_horizontal.py
@@ -1,0 +1,38 @@
+from typing import Tuple, List, Dict, Any
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from app.models.piano_segnaletica_orizzontale import (
+    PianoSegnaleticaOrizzontale,
+    SegnaleticaOrizzontaleItem,
+)
+from .inventory_pdf import build_inventory_pdf
+
+
+def aggregate_items(db: Session, year: int) -> List[Dict[str, Any]]:
+    """Return SegnaleticaOrizzontaleItem counts grouped by description for ``year``."""
+    rows = (
+        db.query(
+            SegnaleticaOrizzontaleItem.descrizione,
+            func.sum(SegnaleticaOrizzontaleItem.quantita).label("count"),
+        )
+        .join(
+            PianoSegnaleticaOrizzontale,
+            SegnaleticaOrizzontaleItem.piano_id == PianoSegnaleticaOrizzontale.id,
+        )
+        .filter(PianoSegnaleticaOrizzontale.anno == year)
+        .group_by(SegnaleticaOrizzontaleItem.descrizione)
+        .order_by(SegnaleticaOrizzontaleItem.descrizione)
+        .all()
+    )
+
+    return [
+        {"name": descrizione, "count": int(count)}
+        for descrizione, count in rows
+    ]
+
+
+def build_signage_horizontal_pdf(db: Session, year: int) -> Tuple[str, str]:
+    """Build a PDF inventory report for SegnaleticaOrizzontaleItem entries."""
+    items = aggregate_items(db, year)
+    return build_inventory_pdf(items, year)

--- a/tests/test_signage_horizontal_pdf.py
+++ b/tests/test_signage_horizontal_pdf.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+from pathlib import Path
+from unittest.mock import patch
+import os
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def create_piano(descr, anno):
+    res = client.post("/piani-orizzontali/", json={"descrizione": descr, "anno": anno})
+    return res.json()["id"]
+
+
+def add_item(piano_id, descr, qty):
+    client.post(f"/piani-orizzontali/{piano_id}/items", json={"descrizione": descr, "quantita": qty})
+
+
+def test_signage_horizontal_pdf_aggregates_items(setup_db, tmp_path):
+    p1 = create_piano("P1", 2023)
+    p2 = create_piano("P2", 2023)
+    p_old = create_piano("Old", 2022)
+
+    add_item(p1, "Linee", 2)
+    add_item(p2, "Linee", 3)
+    add_item(p1, "Stop", 1)
+    add_item(p_old, "Stop", 5)
+
+    captured = {}
+    real_build = __import__("app.services.inventory_pdf", fromlist=["build_inventory_pdf"]).build_inventory_pdf
+
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
+
+    def capture_build(items, year):
+        pdf_path, html_path = real_build(items, year)
+        captured["items"] = items
+        captured["pdf"] = pdf_path
+        captured["html"] = html_path
+        captured["html_text"] = Path(html_path).read_text()
+        return pdf_path, html_path
+
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        with patch("app.services.signage_horizontal.build_inventory_pdf", side_effect=capture_build):
+            res = client.get("/inventario/signage-horizontal/pdf?year=2023")
+
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "application/pdf"
+    assert sorted(captured["items"], key=lambda x: x["name"]) == [
+        {"name": "Linee", "count": 5},
+        {"name": "Stop", "count": 1},
+    ]
+    assert "Inventario 2023" in captured["html_text"]
+    assert "Linee" in captured["html_text"]
+    assert "5" in captured["html_text"]
+    assert not os.path.exists(captured["pdf"])
+    assert not os.path.exists(captured["html"])


### PR DESCRIPTION
## Summary
- add service to aggregate horizontal signage items and generate PDF
- expose `/inventario/signage-horizontal/pdf` endpoint
- test aggregation and PDF generation cleanup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6879019fc4c48323b4aaac8bca27f248