### PR TITLE
Implement item listing for horizontal signage

### DIFF
--- a/app/crud/piano_segnaletica_orizzontale.py
+++ b/app/crud/piano_segnaletica_orizzontale.py
@@ -16,14 +16,20 @@ def create_piano(db: Session, data):
 def get_piani(db: Session, search: str | None = None, anno: int | None = None):
     query = db.query(PianoSegnaleticaOrizzontale)
     if search:
-        query = query.filter(PianoSegnaleticaOrizzontale.descrizione.ilike(f"%{search}%"))
+        query = query.filter(
+            PianoSegnaleticaOrizzontale.descrizione.ilike(f"%{search}%")
+        )
     if anno is not None:
         query = query.filter(PianoSegnaleticaOrizzontale.anno == anno)
     return query.all()
 
 
 def update_piano(db: Session, piano_id: str, data):
-    db_obj = db.query(PianoSegnaleticaOrizzontale).filter(PianoSegnaleticaOrizzontale.id == piano_id).first()
+    db_obj = (
+        db.query(PianoSegnaleticaOrizzontale)
+        .filter(PianoSegnaleticaOrizzontale.id == piano_id)
+        .first()
+    )
     if not db_obj:
         return None
     for key, value in data.dict(exclude_unset=True).items():
@@ -34,7 +40,11 @@ def update_piano(db: Session, piano_id: str, data):
 
 
 def delete_piano(db: Session, piano_id: str):
-    db_obj = db.query(PianoSegnaleticaOrizzontale).filter(PianoSegnaleticaOrizzontale.id == piano_id).first()
+    db_obj = (
+        db.query(PianoSegnaleticaOrizzontale)
+        .filter(PianoSegnaleticaOrizzontale.id == piano_id)
+        .first()
+    )
     if db_obj:
         db.delete(db_obj)
         db.commit()
@@ -42,7 +52,11 @@ def delete_piano(db: Session, piano_id: str):
 
 
 def add_item(db: Session, piano_id: str, data):
-    db_piano = db.query(PianoSegnaleticaOrizzontale).filter(PianoSegnaleticaOrizzontale.id == piano_id).first()
+    db_piano = (
+        db.query(PianoSegnaleticaOrizzontale)
+        .filter(PianoSegnaleticaOrizzontale.id == piano_id)
+        .first()
+    )
     if not db_piano:
         return None
     item = SegnaleticaOrizzontaleItem(**data.dict(), piano_id=piano_id)
@@ -52,8 +66,27 @@ def add_item(db: Session, piano_id: str, data):
     return item
 
 
+def get_items(db: Session, piano_id: str):
+    db_piano = (
+        db.query(PianoSegnaleticaOrizzontale)
+        .filter(PianoSegnaleticaOrizzontale.id == piano_id)
+        .first()
+    )
+    if not db_piano:
+        return None
+    return (
+        db.query(SegnaleticaOrizzontaleItem)
+        .filter(SegnaleticaOrizzontaleItem.piano_id == piano_id)
+        .all()
+    )
+
+
 def update_item(db: Session, item_id: str, data):
-    db_item = db.query(SegnaleticaOrizzontaleItem).filter(SegnaleticaOrizzontaleItem.id == item_id).first()
+    db_item = (
+        db.query(SegnaleticaOrizzontaleItem)
+        .filter(SegnaleticaOrizzontaleItem.id == item_id)
+        .first()
+    )
     if not db_item:
         return None
     for key, value in data.dict(exclude_unset=True).items():
@@ -64,7 +97,11 @@ def update_item(db: Session, item_id: str, data):
 
 
 def delete_item(db: Session, item_id: str):
-    db_obj = db.query(SegnaleticaOrizzontaleItem).filter(SegnaleticaOrizzontaleItem.id == item_id).first()
+    db_obj = (
+        db.query(SegnaleticaOrizzontaleItem)
+        .filter(SegnaleticaOrizzontaleItem.id == item_id)
+        .first()
+    )
     if db_obj:
         db.delete(db_obj)
         db.commit()

--- a/app/routes/piani_orizzontali.py
+++ b/app/routes/piani_orizzontali.py
@@ -14,7 +14,9 @@ router = APIRouter(prefix="/piani-orizzontali", tags=["Piani Segnaletica Orizzon
 
 
 @router.post("/", response_model=PianoSegnaleticaOrizzontaleResponse)
-def create_piano_route(data: PianoSegnaleticaOrizzontaleCreate, db: Session = Depends(get_db)):
+def create_piano_route(
+    data: PianoSegnaleticaOrizzontaleCreate, db: Session = Depends(get_db)
+):
     return crud.create_piano(db, data)
 
 
@@ -57,6 +59,16 @@ def add_item_route(
     if not item:
         raise HTTPException(status_code=404, detail="Piano not found")
     return item
+
+
+@router.get(
+    "/{piano_id}/items", response_model=list[SegnaleticaOrizzontaleItemResponse]
+)
+def list_items(piano_id: str, db: Session = Depends(get_db)):
+    items = crud.get_items(db, piano_id)
+    if items is None:
+        raise HTTPException(status_code=404, detail="Piano not found")
+    return items
 
 
 @router.put("/items/{item_id}", response_model=SegnaleticaOrizzontaleItemResponse)

--- a/tests/test_piani_orizzontali.py
+++ b/tests/test_piani_orizzontali.py
@@ -37,3 +37,26 @@ def test_update_item_not_found(setup_db):
         json={"descrizione": "X"},
     )
     assert response.status_code == 404
+
+
+def test_list_items(setup_db):
+    res = client.post(
+        "/piani-orizzontali/",
+        json={"descrizione": "Piano", "anno": 2024},
+    )
+    piano_id = res.json()["id"]
+
+    item1 = client.post(
+        f"/piani-orizzontali/{piano_id}/items",
+        json={"descrizione": "A", "quantita": 1},
+    ).json()
+    item2 = client.post(
+        f"/piani-orizzontali/{piano_id}/items",
+        json={"descrizione": "B", "quantita": 2},
+    ).json()
+
+    list_res = client.get(f"/piani-orizzontali/{piano_id}/items")
+    assert list_res.status_code == 200
+    assert sorted(list_res.json(), key=lambda x: x["id"]) == sorted(
+        [item1, item2], key=lambda x: x["id"]
+    )


### PR DESCRIPTION
## Summary
- add CRUD helper to list SegnaleticaOrizzontaleItem by plan
- expose `/piani-orizzontali/{piano_id}/items` GET endpoint
- test new endpoint in `test_piani_orizzontali`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68791aa092b0832394f0ce54105f9c98