### PR TITLE
Add luogo and data fields to horizontal signage

### DIFF
--- a/app/models/piano_segnaletica_orizzontale.py
+++ b/app/models/piano_segnaletica_orizzontale.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Integer, ForeignKey
+from sqlalchemy import Column, String, Integer, ForeignKey, Date
 from sqlalchemy.orm import relationship
 from app.database import Base
 import uuid
@@ -25,5 +25,7 @@ class SegnaleticaOrizzontaleItem(Base):
     piano_id = Column(String, ForeignKey("piani_segnaletica_orizzontale.id"), nullable=False)
     descrizione = Column(String, nullable=False)
     quantita = Column(Integer, nullable=False, default=1)
+    luogo = Column(String, nullable=True)
+    data = Column(Date, nullable=True)
 
     piano = relationship("PianoSegnaleticaOrizzontale", back_populates="items")

--- a/app/schemas/piano_segnaletica_orizzontale.py
+++ b/app/schemas/piano_segnaletica_orizzontale.py
@@ -1,15 +1,20 @@
 from pydantic import BaseModel
+from datetime import date
 from typing import List
 
 
 class SegnaleticaOrizzontaleItemCreate(BaseModel):
     descrizione: str
     quantita: int = 1
+    luogo: str | None = None
+    data: date | None = None
 
 
 class SegnaleticaOrizzontaleItemUpdate(BaseModel):
     descrizione: str | None = None
     quantita: int | None = None
+    luogo: str | None = None
+    data: date | None = None
 
 
 class SegnaleticaOrizzontaleItemResponse(SegnaleticaOrizzontaleItemCreate):

--- a/migrations/versions/0007_add_luogo_data_to_horizontal_items.py
+++ b/migrations/versions/0007_add_luogo_data_to_horizontal_items.py
@@ -1,0 +1,21 @@
+"""add luogo and data to segnaletica_orizzontale_items"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0007_add_luogo_data_to_horizontal_items"
+down_revision = "0006_inventory_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("segnaletica_orizzontale_items") as batch_op:
+        batch_op.add_column(sa.Column("luogo", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("data", sa.Date(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("segnaletica_orizzontale_items") as batch_op:
+        batch_op.drop_column("data")
+        batch_op.drop_column("luogo")

--- a/tests/test_piani_orizzontali.py
+++ b/tests/test_piani_orizzontali.py
@@ -60,3 +60,25 @@ def test_list_items(setup_db):
     assert sorted(list_res.json(), key=lambda x: x["id"]) == sorted(
         [item1, item2], key=lambda x: x["id"]
     )
+
+
+def test_create_item_with_extra_fields(setup_db):
+    res = client.post(
+        "/piani-orizzontali/",
+        json={"descrizione": "Piano", "anno": 2024},
+    )
+    piano_id = res.json()["id"]
+
+    item_res = client.post(
+        f"/piani-orizzontali/{piano_id}/items",
+        json={
+            "descrizione": "Segn",
+            "quantita": 1,
+            "luogo": "Via",
+            "data": "2024-05-01",
+        },
+    )
+    assert item_res.status_code == 200
+    item = item_res.json()
+    assert item["luogo"] == "Via"
+    assert item["data"] == "2024-05-01"


### PR DESCRIPTION
## Summary
- add `luogo` and `data` columns to `SegnaleticaOrizzontaleItem`
- expose new attributes in schemas
- migration for new columns
- test creation of an item with the new fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68791c0ee9648323a38bf85de4cc94c4