### PR TITLE
Fix duplicate import

### DIFF
--- a/app/schemas/piano_segnaletica_orizzontale.py
+++ b/app/schemas/piano_segnaletica_orizzontale.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel
 from datetime import date
 from typing import List
-from datetime import date
 
 
 class SegnaleticaOrizzontaleItemCreate(BaseModel):


### PR DESCRIPTION
## Summary
- remove duplicate `date` import in piano_segnaletica_orizzontale schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68791f130d248323b283faf7c205cc7a