### PR TITLE
Add start script and use in Dockerfile & Procfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,11 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip cache purge || true && pip install --no-cache-dir -r requirements.txt
 
+COPY start.sh ./
+RUN chmod +x start.sh
+
 COPY . .
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["./start.sh"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn app.main:app --host 0.0.0.0 --port $PORT
+web: ./start.sh

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -e
+alembic upgrade head
+exec uvicorn app.main:app --host 0.0.0.0 --port "${PORT:-8000}"


### PR DESCRIPTION
## Summary
- add an entrypoint script running migrations before starting Uvicorn
- update `Dockerfile` to use the new script
- update `Procfile` to use the new script

## Testing
- `./scripts/test.sh` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687928afd5288323840d85ec99564d99