### PR TITLE
Implement Segnalazione model and API

### DIFF
--- a/app/crud/segnalazione.py
+++ b/app/crud/segnalazione.py
@@ -1,0 +1,42 @@
+from sqlalchemy.orm import Session
+from app.models.segnalazione import Segnalazione
+from app.models.user import User
+
+
+def create_segnalazione(db: Session, data, user: User):
+    db_obj = Segnalazione(**data.dict(), user_id=user.id)
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_segnalazioni(db: Session, user: User):
+    return db.query(Segnalazione).filter(Segnalazione.user_id == user.id).all()
+
+
+def update_segnalazione(db: Session, segnalazione_id: str, data, user: User):
+    db_obj = (
+        db.query(Segnalazione)
+        .filter(Segnalazione.id == segnalazione_id, Segnalazione.user_id == user.id)
+        .first()
+    )
+    if not db_obj:
+        return None
+    for key, value in data.dict().items():
+        setattr(db_obj, key, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def delete_segnalazione(db: Session, segnalazione_id: str, user: User):
+    db_obj = (
+        db.query(Segnalazione)
+        .filter(Segnalazione.id == segnalazione_id, Segnalazione.user_id == user.id)
+        .first()
+    )
+    if db_obj:
+        db.delete(db_obj)
+        db.commit()
+    return db_obj

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from app.routes import (
     segnaletica_temporanea,
     segnaletica_verticale,
     piani_orizzontali,
+    segnalazioni,
 )
 from app.routes.orari import router as orari_router
 from app.routes import inventory
@@ -52,6 +53,7 @@ app.include_router(todo.router)
 app.include_router(determinazioni.router)
 app.include_router(pdf_files.router)
 app.include_router(dispositivi.router)
+app.include_router(segnalazioni.router)
 app.include_router(segnaletica_temporanea.router)
 app.include_router(segnaletica_verticale.router)
 app.include_router(piani_orizzontali.router)

--- a/app/models/segnalazione.py
+++ b/app/models/segnalazione.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, String, DateTime, Float, ForeignKey
+from sqlalchemy.orm import relationship
+from app.database import Base
+import uuid
+
+
+class Segnalazione(Base):
+    __tablename__ = "segnalazioni"
+
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
+    tipo = Column(String, nullable=False)
+    stato = Column(String, nullable=False)
+    priorita = Column(String, nullable=True)
+    data = Column(DateTime, nullable=False)
+    descrizione = Column(String, nullable=False)
+    latitudine = Column(Float, nullable=True)
+    longitudine = Column(Float, nullable=True)
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    user = relationship("User", back_populates="segnalazioni")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -12,3 +12,4 @@ class User(Base):
     todos = relationship("ToDo", back_populates="user")
     events = relationship("Event", back_populates="user")
     turni = relationship("Turno", back_populates="user")
+    segnalazioni = relationship("Segnalazione", back_populates="user")

--- a/app/routes/segnalazioni.py
+++ b/app/routes/segnalazioni.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.dependencies import get_db, get_current_user
+from app.models.user import User
+from app.schemas.segnalazione import SegnalazioneCreate, SegnalazioneResponse
+from app.crud import segnalazione as crud
+
+router = APIRouter(prefix="/segnalazioni", tags=["Segnalazioni"])
+
+
+@router.post("/", response_model=SegnalazioneResponse)
+def create_segnalazione_route(
+    data: SegnalazioneCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return crud.create_segnalazione(db, data, current_user)
+
+
+@router.get("/", response_model=list[SegnalazioneResponse])
+def list_segnalazioni(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return crud.get_segnalazioni(db, current_user)
+
+
+@router.put("/{segnalazione_id}", response_model=SegnalazioneResponse)
+def update_segnalazione_route(
+    segnalazione_id: str,
+    data: SegnalazioneCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    db_obj = crud.update_segnalazione(db, segnalazione_id, data, current_user)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnalazione not found")
+    return db_obj
+
+
+@router.delete("/{segnalazione_id}")
+def delete_segnalazione_route(
+    segnalazione_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    db_obj = crud.delete_segnalazione(db, segnalazione_id, current_user)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnalazione not found")
+    return {"ok": True}

--- a/app/schemas/segnalazione.py
+++ b/app/schemas/segnalazione.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from enum import Enum
+from pydantic import BaseModel
+
+
+class TipoSegnalazione(str, Enum):
+    INCIDENTE = "incidente"
+    VIOLAZIONE = "violazione"
+    ALTRO = "altro"
+
+
+class StatoSegnalazione(str, Enum):
+    APERTA = "aperta"
+    IN_LAVORAZIONE = "in lavorazione"
+    CHIUSA = "chiusa"
+
+
+class SegnalazioneCreate(BaseModel):
+    tipo: TipoSegnalazione
+    stato: StatoSegnalazione
+    priorita: str | None = None
+    data: datetime
+    descrizione: str
+    latitudine: float | None = None
+    longitudine: float | None = None
+
+
+class SegnalazioneResponse(SegnalazioneCreate):
+    id: str
+    user_id: str
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/migrations/versions/0008_create_segnalazioni_table.py
+++ b/migrations/versions/0008_create_segnalazioni_table.py
@@ -1,0 +1,30 @@
+"""create segnalazioni table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0008_create_segnalazioni_table"
+down_revision = "0007_add_luogo_data_to_horizontal_items"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "segnalazioni",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("tipo", sa.String(), nullable=False),
+        sa.Column("stato", sa.String(), nullable=False),
+        sa.Column("priorita", sa.String(), nullable=True),
+        sa.Column("data", sa.DateTime(), nullable=False),
+        sa.Column("descrizione", sa.String(), nullable=False),
+        sa.Column("latitudine", sa.Float(), nullable=True),
+        sa.Column("longitudine", sa.Float(), nullable=True),
+        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id"), nullable=False),
+    )
+    op.create_index("ix_segnalazioni_id", "segnalazioni", ["id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_segnalazioni_id", table_name="segnalazioni")
+    op.drop_table("segnalazioni")

--- a/tests/test_segnalazioni.py
+++ b/tests/test_segnalazioni.py
@@ -1,0 +1,177 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def auth_user(email: str):
+    resp = client.post(
+        "/users/",
+        json={"email": email, "password": "secret", "nome": "Test"},
+    )
+    user_id = resp.json()["id"]
+    token = client.post("/login", json={"email": email, "password": "secret"}).json()[
+        "access_token"
+    ]
+    return {"Authorization": f"Bearer {token}"}, user_id
+
+
+def test_create_segnalazione(setup_db):
+    headers, user_id = auth_user("seg@example.com")
+    data = {
+        "tipo": "incidente",
+        "stato": "aperta",
+        "priorita": "alta",
+        "data": "2024-01-01T10:00:00",
+        "descrizione": "Desc",
+        "latitudine": 10.0,
+        "longitudine": 20.0,
+    }
+    response = client.post("/segnalazioni/", json=data, headers=headers)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tipo"] == "incidente"
+    assert body["user_id"] == user_id
+    assert "id" in body
+
+
+def test_update_segnalazione(setup_db):
+    headers, _ = auth_user("upd@example.com")
+    create = client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": "alta",
+            "data": "2024-01-01T10:00:00",
+            "descrizione": "Old",
+            "latitudine": 1.0,
+            "longitudine": 2.0,
+        },
+        headers=headers,
+    )
+    seg_id = create.json()["id"]
+    response = client.put(
+        f"/segnalazioni/{seg_id}",
+        json={
+            "tipo": "violazione",
+            "stato": "in lavorazione",
+            "priorita": "bassa",
+            "data": "2024-02-01T12:00:00",
+            "descrizione": "New",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["stato"] == "in lavorazione"
+
+
+def test_list_segnalazioni(setup_db):
+    headers, _ = auth_user("list@example.com")
+    client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": "alta",
+            "data": "2024-01-01T10:00:00",
+            "descrizione": "A",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=headers,
+    )
+    client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "violazione",
+            "stato": "chiusa",
+            "priorita": "bassa",
+            "data": "2024-02-01T10:00:00",
+            "descrizione": "B",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=headers,
+    )
+    res = client.get("/segnalazioni/", headers=headers)
+    assert res.status_code == 200
+    assert len(res.json()) == 2
+
+
+def test_delete_segnalazione(setup_db):
+    headers, _ = auth_user("del@example.com")
+    res = client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": "alta",
+            "data": "2024-01-01T10:00:00",
+            "descrizione": "Del",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=headers,
+    )
+    seg_id = res.json()["id"]
+    response = client.delete(f"/segnalazioni/{seg_id}", headers=headers)
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert client.get("/segnalazioni/", headers=headers).json() == []
+
+
+def test_user_isolated_segnalazioni(setup_db):
+    h1, id1 = auth_user("u1@example.com")
+    h2, id2 = auth_user("u2@example.com")
+
+    client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": "alta",
+            "data": "2024-01-01T10:00:00",
+            "descrizione": "U1",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=h1,
+    )
+    client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": "alta",
+            "data": "2024-02-01T10:00:00",
+            "descrizione": "U2",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=h2,
+    )
+    client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": "alta",
+            "data": "2024-03-01T10:00:00",
+            "descrizione": "U1B",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=h1,
+    )
+
+    res1 = client.get("/segnalazioni/", headers=h1)
+    res2 = client.get("/segnalazioni/", headers=h2)
+
+    assert len(res1.json()) == 2
+    assert len(res2.json()) == 1
+    assert all(s["user_id"] == id1 for s in res1.json())
+    assert all(s["user_id"] == id2 for s in res2.json())


### PR DESCRIPTION
## Summary
- add Segnalazione SQLAlchemy model
- expose segnalazioni CRUD routes
- define Pydantic schema for segnalazioni
- implement CRUD helper
- create Alembic migration for segnalazioni table
- register segnalazioni router
- add integration tests for segnalazioni API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: could not fetch packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68793cccc92c8323a8ddc0dce45a6b78