### PR TITLE
Add big yellow WIP notice on inventory page

### DIFF
--- a/app/services/inventory_pdf.py
+++ b/app/services/inventory_pdf.py
@@ -20,6 +20,7 @@ def build_inventory_pdf(items: List[Dict[str, Any]], year: int) -> Tuple[str, st
     <html>
     <body>
     <h1>Inventario {year}</h1>
+    <h1 style='font-size:64px; color:yellow;'>🚧 LAVORI IN CORSO 🚧</h1>
     <table border='1' style='border-collapse:collapse;'>
         <tr><th>Nome</th><th>Quantità</th></tr>
         {rows_html}


### PR DESCRIPTION
## Summary
- show a big yellow "🚧 LAVORI IN CORSO 🚧" heading on the inventory PDF page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687948f423188323b21a538873a23ec8