### PR TITLE
Add segnalazione tests and fields update

### DIFF
--- a/app/crud/segnalazione.py
+++ b/app/crud/segnalazione.py
@@ -15,6 +15,14 @@ def get_segnalazioni(db: Session, user: User):
     return db.query(Segnalazione).filter(Segnalazione.user_id == user.id).all()
 
 
+def get_segnalazione(db: Session, segnalazione_id: str, user: User):
+    return (
+        db.query(Segnalazione)
+        .filter(Segnalazione.id == segnalazione_id, Segnalazione.user_id == user.id)
+        .first()
+    )
+
+
 def update_segnalazione(db: Session, segnalazione_id: str, data, user: User):
     db_obj = (
         db.query(Segnalazione)
@@ -24,6 +32,21 @@ def update_segnalazione(db: Session, segnalazione_id: str, data, user: User):
     if not db_obj:
         return None
     for key, value in data.dict().items():
+        setattr(db_obj, key, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def patch_segnalazione(db: Session, segnalazione_id: str, data, user: User):
+    db_obj = (
+        db.query(Segnalazione)
+        .filter(Segnalazione.id == segnalazione_id, Segnalazione.user_id == user.id)
+        .first()
+    )
+    if not db_obj:
+        return None
+    for key, value in data.dict(exclude_unset=True).items():
         setattr(db_obj, key, value)
     db.commit()
     db.refresh(db_obj)

--- a/app/models/segnalazione.py
+++ b/app/models/segnalazione.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, DateTime, Float, ForeignKey
+from sqlalchemy import Column, String, DateTime, Float, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 from app.database import Base
 import uuid
@@ -10,8 +10,8 @@ class Segnalazione(Base):
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
     tipo = Column(String, nullable=False)
     stato = Column(String, nullable=False)
-    priorita = Column(String, nullable=True)
-    data = Column(DateTime, nullable=False)
+    priorita = Column(Integer, nullable=True)
+    data_segnalazione = Column(DateTime, nullable=False)
     descrizione = Column(String, nullable=False)
     latitudine = Column(Float, nullable=True)
     longitudine = Column(Float, nullable=True)

--- a/app/routes/segnalazioni.py
+++ b/app/routes/segnalazioni.py
@@ -2,7 +2,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.dependencies import get_db, get_current_user
 from app.models.user import User
-from app.schemas.segnalazione import SegnalazioneCreate, SegnalazioneResponse
+from app.schemas.segnalazione import (
+    SegnalazioneCreate,
+    SegnalazioneResponse,
+    SegnalazionePatch,
+)
 from app.crud import segnalazione as crud
 
 router = APIRouter(prefix="/segnalazioni", tags=["Segnalazioni"])
@@ -25,6 +29,18 @@ def list_segnalazioni(
     return crud.get_segnalazioni(db, current_user)
 
 
+@router.get("/{segnalazione_id}", response_model=SegnalazioneResponse)
+def get_segnalazione_route(
+    segnalazione_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    db_obj = crud.get_segnalazione(db, segnalazione_id, current_user)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnalazione not found")
+    return db_obj
+
+
 @router.put("/{segnalazione_id}", response_model=SegnalazioneResponse)
 def update_segnalazione_route(
     segnalazione_id: str,
@@ -33,6 +49,19 @@ def update_segnalazione_route(
     current_user: User = Depends(get_current_user),
 ):
     db_obj = crud.update_segnalazione(db, segnalazione_id, data, current_user)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnalazione not found")
+    return db_obj
+
+
+@router.patch("/{segnalazione_id}", response_model=SegnalazioneResponse)
+def patch_segnalazione_route(
+    segnalazione_id: str,
+    data: SegnalazionePatch,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    db_obj = crud.patch_segnalazione(db, segnalazione_id, data, current_user)
     if not db_obj:
         raise HTTPException(status_code=404, detail="Segnalazione not found")
     return db_obj

--- a/app/schemas/segnalazione.py
+++ b/app/schemas/segnalazione.py
@@ -18,11 +18,16 @@ class StatoSegnalazione(str, Enum):
 class SegnalazioneCreate(BaseModel):
     tipo: TipoSegnalazione
     stato: StatoSegnalazione
-    priorita: str | None = None
-    data: datetime
+    priorita: int | None = None
+    data_segnalazione: datetime
     descrizione: str
     latitudine: float | None = None
     longitudine: float | None = None
+
+
+class SegnalazionePatch(BaseModel):
+    stato: StatoSegnalazione | None = None
+    priorita: int | None = None
 
 
 class SegnalazioneResponse(SegnalazioneCreate):

--- a/tests/test_segnalazioni.py
+++ b/tests/test_segnalazioni.py
@@ -22,8 +22,8 @@ def test_create_segnalazione(setup_db):
     data = {
         "tipo": "incidente",
         "stato": "aperta",
-        "priorita": "alta",
-        "data": "2024-01-01T10:00:00",
+        "priorita": 1,
+        "data_segnalazione": "2024-01-01T10:00:00",
         "descrizione": "Desc",
         "latitudine": 10.0,
         "longitudine": 20.0,
@@ -43,8 +43,8 @@ def test_update_segnalazione(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-01-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
             "descrizione": "Old",
             "latitudine": 1.0,
             "longitudine": 2.0,
@@ -57,8 +57,8 @@ def test_update_segnalazione(setup_db):
         json={
             "tipo": "violazione",
             "stato": "in lavorazione",
-            "priorita": "bassa",
-            "data": "2024-02-01T12:00:00",
+            "priorita": 2,
+            "data_segnalazione": "2024-02-01T12:00:00",
             "descrizione": "New",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -69,6 +69,78 @@ def test_update_segnalazione(setup_db):
     assert response.json()["stato"] == "in lavorazione"
 
 
+def test_get_segnalazione(setup_db):
+    headers, _ = auth_user("get@example.com")
+    res = client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
+            "descrizione": "Desc",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=headers,
+    )
+    seg_id = res.json()["id"]
+    get_res = client.get(f"/segnalazioni/{seg_id}", headers=headers)
+    assert get_res.status_code == 200
+    assert get_res.json()["id"] == seg_id
+
+
+def test_patch_stato(setup_db):
+    headers, _ = auth_user("patchstato@example.com")
+    res = client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
+            "descrizione": "ToPatch",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=headers,
+    )
+    seg_id = res.json()["id"]
+    patch_res = client.patch(
+        f"/segnalazioni/{seg_id}",
+        json={"stato": "chiusa"},
+        headers=headers,
+    )
+    assert patch_res.status_code == 200
+    assert patch_res.json()["stato"] == "chiusa"
+    assert patch_res.json()["priorita"] == 1
+
+
+def test_patch_priorita(setup_db):
+    headers, _ = auth_user("patchprio@example.com")
+    res = client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
+            "descrizione": "ToPatch",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=headers,
+    )
+    seg_id = res.json()["id"]
+    patch_res = client.patch(
+        f"/segnalazioni/{seg_id}",
+        json={"priorita": 2},
+        headers=headers,
+    )
+    assert patch_res.status_code == 200
+    assert patch_res.json()["priorita"] == 2
+
+
 def test_list_segnalazioni(setup_db):
     headers, _ = auth_user("list@example.com")
     client.post(
@@ -76,8 +148,8 @@ def test_list_segnalazioni(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-01-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
             "descrizione": "A",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -89,8 +161,8 @@ def test_list_segnalazioni(setup_db):
         json={
             "tipo": "violazione",
             "stato": "chiusa",
-            "priorita": "bassa",
-            "data": "2024-02-01T10:00:00",
+            "priorita": 2,
+            "data_segnalazione": "2024-02-01T10:00:00",
             "descrizione": "B",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -109,8 +181,8 @@ def test_delete_segnalazione(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-01-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
             "descrizione": "Del",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -133,8 +205,8 @@ def test_user_isolated_segnalazioni(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-01-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
             "descrizione": "U1",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -146,8 +218,8 @@ def test_user_isolated_segnalazioni(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-02-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-02-01T10:00:00",
             "descrizione": "U2",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -159,8 +231,8 @@ def test_user_isolated_segnalazioni(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-03-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-03-01T10:00:00",
             "descrizione": "U1B",
             "latitudine": 0.0,
             "longitudine": 0.0,


### PR DESCRIPTION
## Summary
- add ability to retrieve and patch segnalazioni
- rename segnalazione fields (`data_segnalazione`, numeric `priorita`)
- update models, schemas, CRUD and routes
- extend tests for segnalazioni including single retrieval and partial update

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68795a91b9f8832381281e28a6ce37b5