### PR TITLE
Implement segnalazione retrieval and patch update

### DIFF
--- a/app/crud/segnalazione.py
+++ b/app/crud/segnalazione.py
@@ -15,6 +15,14 @@ def get_segnalazioni(db: Session, user: User):
     return db.query(Segnalazione).filter(Segnalazione.user_id == user.id).all()
 
 
+def get_segnalazione(db: Session, segnalazione_id: str, user: User):
+    return (
+        db.query(Segnalazione)
+        .filter(Segnalazione.id == segnalazione_id, Segnalazione.user_id == user.id)
+        .first()
+    )
+
+
 def update_segnalazione(db: Session, segnalazione_id: str, data, user: User):
     db_obj = (
         db.query(Segnalazione)
@@ -24,6 +32,21 @@ def update_segnalazione(db: Session, segnalazione_id: str, data, user: User):
     if not db_obj:
         return None
     for key, value in data.dict().items():
+        setattr(db_obj, key, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def patch_segnalazione(db: Session, segnalazione_id: str, data, user: User):
+    db_obj = (
+        db.query(Segnalazione)
+        .filter(Segnalazione.id == segnalazione_id, Segnalazione.user_id == user.id)
+        .first()
+    )
+    if not db_obj:
+        return None
+    for key, value in data.dict(exclude_unset=True).items():
         setattr(db_obj, key, value)
     db.commit()
     db.refresh(db_obj)

--- a/app/routes/segnalazioni.py
+++ b/app/routes/segnalazioni.py
@@ -2,7 +2,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.dependencies import get_db, get_current_user
 from app.models.user import User
-from app.schemas.segnalazione import SegnalazioneCreate, SegnalazioneResponse
+from app.schemas.segnalazione import (
+    SegnalazioneCreate,
+    SegnalazioneResponse,
+    SegnalazioneUpdate,
+)
 from app.crud import segnalazione as crud
 
 router = APIRouter(prefix="/segnalazioni", tags=["Segnalazioni"])
@@ -25,6 +29,18 @@ def list_segnalazioni(
     return crud.get_segnalazioni(db, current_user)
 
 
+@router.get("/{segnalazione_id}", response_model=SegnalazioneResponse)
+def get_segnalazione_route(
+    segnalazione_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    db_obj = crud.get_segnalazione(db, segnalazione_id, current_user)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnalazione not found")
+    return db_obj
+
+
 @router.put("/{segnalazione_id}", response_model=SegnalazioneResponse)
 def update_segnalazione_route(
     segnalazione_id: str,
@@ -33,6 +49,19 @@ def update_segnalazione_route(
     current_user: User = Depends(get_current_user),
 ):
     db_obj = crud.update_segnalazione(db, segnalazione_id, data, current_user)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnalazione not found")
+    return db_obj
+
+
+@router.patch("/{segnalazione_id}", response_model=SegnalazioneResponse)
+def patch_segnalazione_route(
+    segnalazione_id: str,
+    data: SegnalazioneUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    db_obj = crud.patch_segnalazione(db, segnalazione_id, data, current_user)
     if not db_obj:
         raise HTTPException(status_code=404, detail="Segnalazione not found")
     return db_obj

--- a/app/schemas/segnalazione.py
+++ b/app/schemas/segnalazione.py
@@ -15,14 +15,21 @@ class StatoSegnalazione(str, Enum):
     CHIUSA = "chiusa"
 
 
-class SegnalazioneCreate(BaseModel):
-    tipo: TipoSegnalazione
-    stato: StatoSegnalazione
+class SegnalazioneBase(BaseModel):
+    tipo: TipoSegnalazione | None = None
+    stato: StatoSegnalazione | None = None
     priorita: str | None = None
-    data: datetime
-    descrizione: str
+    data: datetime | None = None
+    descrizione: str | None = None
     latitudine: float | None = None
     longitudine: float | None = None
+
+
+class SegnalazioneCreate(SegnalazioneBase):
+    tipo: TipoSegnalazione
+    stato: StatoSegnalazione
+    data: datetime
+    descrizione: str
 
 
 class SegnalazioneResponse(SegnalazioneCreate):
@@ -32,3 +39,9 @@ class SegnalazioneResponse(SegnalazioneCreate):
     model_config = {
         "from_attributes": True,
     }
+
+
+class SegnalazioneUpdate(SegnalazioneBase):
+    """Schema for partial update of a segnalazione."""
+
+    pass

--- a/tests/test_segnalazioni.py
+++ b/tests/test_segnalazioni.py
@@ -36,6 +36,27 @@ def test_create_segnalazione(setup_db):
     assert "id" in body
 
 
+def test_get_segnalazione(setup_db):
+    headers, _ = auth_user("get@example.com")
+    res = client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": "alta",
+            "data": "2024-01-01T10:00:00",
+            "descrizione": "Desc",
+            "latitudine": 1.0,
+            "longitudine": 2.0,
+        },
+        headers=headers,
+    )
+    seg_id = res.json()["id"]
+    response = client.get(f"/segnalazioni/{seg_id}", headers=headers)
+    assert response.status_code == 200
+    assert response.json()["id"] == seg_id
+
+
 def test_update_segnalazione(setup_db):
     headers, _ = auth_user("upd@example.com")
     create = client.post(
@@ -67,6 +88,33 @@ def test_update_segnalazione(setup_db):
     )
     assert response.status_code == 200
     assert response.json()["stato"] == "in lavorazione"
+
+
+def test_patch_segnalazione(setup_db):
+    headers, _ = auth_user("patch@example.com")
+    res = client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "incidente",
+            "stato": "aperta",
+            "priorita": "alta",
+            "data": "2024-01-01T10:00:00",
+            "descrizione": "Old",
+            "latitudine": 1.0,
+            "longitudine": 2.0,
+        },
+        headers=headers,
+    )
+    seg_id = res.json()["id"]
+    response = client.patch(
+        f"/segnalazioni/{seg_id}",
+        json={"descrizione": "Patched"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["descrizione"] == "Patched"
+    assert data["tipo"] == "incidente"
 
 
 def test_list_segnalazioni(setup_db):


### PR DESCRIPTION
## Summary
- support partial updates of segnalazioni
- allow retrieval of a single segnalazione
- expose new endpoints
- extend tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68795a8fba588323a23c0e8fff640f6c