### PR TITLE
Add segnalazioni retrieval & patch endpoints

### DIFF
--- a/app/crud/segnalazione.py
+++ b/app/crud/segnalazione.py
@@ -15,6 +15,14 @@ def get_segnalazioni(db: Session, user: User):
     return db.query(Segnalazione).filter(Segnalazione.user_id == user.id).all()
 
 
+def get_segnalazione(db: Session, segnalazione_id: str, user: User):
+    return (
+        db.query(Segnalazione)
+        .filter(Segnalazione.id == segnalazione_id, Segnalazione.user_id == user.id)
+        .first()
+    )
+
+
 def update_segnalazione(db: Session, segnalazione_id: str, data, user: User):
     db_obj = (
         db.query(Segnalazione)
@@ -24,6 +32,21 @@ def update_segnalazione(db: Session, segnalazione_id: str, data, user: User):
     if not db_obj:
         return None
     for key, value in data.dict().items():
+        setattr(db_obj, key, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def patch_segnalazione(db: Session, segnalazione_id: str, data, user: User):
+    db_obj = (
+        db.query(Segnalazione)
+        .filter(Segnalazione.id == segnalazione_id, Segnalazione.user_id == user.id)
+        .first()
+    )
+    if not db_obj:
+        return None
+    for key, value in data.dict(exclude_unset=True).items():
         setattr(db_obj, key, value)
     db.commit()
     db.refresh(db_obj)

--- a/app/routes/segnalazioni.py
+++ b/app/routes/segnalazioni.py
@@ -2,7 +2,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.dependencies import get_db, get_current_user
 from app.models.user import User
-from app.schemas.segnalazione import SegnalazioneCreate, SegnalazioneResponse
+from app.schemas.segnalazione import (
+    SegnalazioneCreate,
+    SegnalazioneResponse,
+    SegnalazioneUpdate,
+)
 from app.crud import segnalazione as crud
 
 router = APIRouter(prefix="/segnalazioni", tags=["Segnalazioni"])
@@ -25,6 +29,18 @@ def list_segnalazioni(
     return crud.get_segnalazioni(db, current_user)
 
 
+@router.get("/{segnalazione_id}", response_model=SegnalazioneResponse)
+def get_segnalazione_route(
+    segnalazione_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    seg = crud.get_segnalazione(db, segnalazione_id, current_user)
+    if not seg:
+        raise HTTPException(status_code=404, detail="Segnalazione not found")
+    return seg
+
+
 @router.put("/{segnalazione_id}", response_model=SegnalazioneResponse)
 def update_segnalazione_route(
     segnalazione_id: str,
@@ -33,6 +49,19 @@ def update_segnalazione_route(
     current_user: User = Depends(get_current_user),
 ):
     db_obj = crud.update_segnalazione(db, segnalazione_id, data, current_user)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnalazione not found")
+    return db_obj
+
+
+@router.patch("/{segnalazione_id}", response_model=SegnalazioneResponse)
+def patch_segnalazione_route(
+    segnalazione_id: str,
+    data: SegnalazioneUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    db_obj = crud.patch_segnalazione(db, segnalazione_id, data, current_user)
     if not db_obj:
         raise HTTPException(status_code=404, detail="Segnalazione not found")
     return db_obj

--- a/app/schemas/segnalazione.py
+++ b/app/schemas/segnalazione.py
@@ -25,6 +25,16 @@ class SegnalazioneCreate(BaseModel):
     longitudine: float | None = None
 
 
+class SegnalazioneUpdate(BaseModel):
+    tipo: TipoSegnalazione | None = None
+    stato: StatoSegnalazione | None = None
+    priorita: str | None = None
+    data: datetime | None = None
+    descrizione: str | None = None
+    latitudine: float | None = None
+    longitudine: float | None = None
+
+
 class SegnalazioneResponse(SegnalazioneCreate):
     id: str
     user_id: str


### PR DESCRIPTION
## Summary
- allow partial updates via `PATCH /segnalazioni/{id}`
- expose `GET /segnalazioni/{id}` endpoint
- support patch data with new `SegnalazioneUpdate` schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68795a90ec5883238c53f6ac408ef3ed