### PR TITLE
Update segnalazione schemas

### DIFF
--- a/app/crud/segnalazione.py
+++ b/app/crud/segnalazione.py
@@ -4,7 +4,9 @@ from app.models.user import User
 
 
 def create_segnalazione(db: Session, data, user: User):
-    db_obj = Segnalazione(**data.dict(), user_id=user.id)
+    data_dict = data.dict()
+    data_dict["data"] = data_dict.pop("data_segnalazione")
+    db_obj = Segnalazione(**data_dict, user_id=user.id)
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)
@@ -23,7 +25,10 @@ def update_segnalazione(db: Session, segnalazione_id: str, data, user: User):
     )
     if not db_obj:
         return None
-    for key, value in data.dict().items():
+    update_data = data.dict(exclude_unset=True)
+    if "data_segnalazione" in update_data:
+        update_data["data"] = update_data.pop("data_segnalazione")
+    for key, value in update_data.items():
         setattr(db_obj, key, value)
     db.commit()
     db.refresh(db_obj)

--- a/app/routes/segnalazioni.py
+++ b/app/routes/segnalazioni.py
@@ -2,7 +2,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.dependencies import get_db, get_current_user
 from app.models.user import User
-from app.schemas.segnalazione import SegnalazioneCreate, SegnalazioneResponse
+from app.schemas.segnalazione import (
+    SegnalazioneCreate,
+    SegnalazioneResponse,
+    SegnalazioneUpdate,
+)
 from app.crud import segnalazione as crud
 
 router = APIRouter(prefix="/segnalazioni", tags=["Segnalazioni"])
@@ -28,7 +32,7 @@ def list_segnalazioni(
 @router.put("/{segnalazione_id}", response_model=SegnalazioneResponse)
 def update_segnalazione_route(
     segnalazione_id: str,
-    data: SegnalazioneCreate,
+    data: SegnalazioneUpdate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):

--- a/app/schemas/segnalazione.py
+++ b/app/schemas/segnalazione.py
@@ -18,11 +18,16 @@ class StatoSegnalazione(str, Enum):
 class SegnalazioneCreate(BaseModel):
     tipo: TipoSegnalazione
     stato: StatoSegnalazione
-    priorita: str | None = None
-    data: datetime
+    priorita: int | None = None
+    data_segnalazione: datetime
     descrizione: str
     latitudine: float | None = None
     longitudine: float | None = None
+
+
+class SegnalazioneUpdate(BaseModel):
+    stato: StatoSegnalazione | None = None
+    priorita: int | None = None
 
 
 class SegnalazioneResponse(SegnalazioneCreate):

--- a/tests/test_segnalazioni.py
+++ b/tests/test_segnalazioni.py
@@ -22,8 +22,8 @@ def test_create_segnalazione(setup_db):
     data = {
         "tipo": "incidente",
         "stato": "aperta",
-        "priorita": "alta",
-        "data": "2024-01-01T10:00:00",
+        "priorita": 1,
+        "data_segnalazione": "2024-01-01T10:00:00",
         "descrizione": "Desc",
         "latitudine": 10.0,
         "longitudine": 20.0,
@@ -43,8 +43,8 @@ def test_update_segnalazione(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-01-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
             "descrizione": "Old",
             "latitudine": 1.0,
             "longitudine": 2.0,
@@ -55,13 +55,8 @@ def test_update_segnalazione(setup_db):
     response = client.put(
         f"/segnalazioni/{seg_id}",
         json={
-            "tipo": "violazione",
             "stato": "in lavorazione",
-            "priorita": "bassa",
-            "data": "2024-02-01T12:00:00",
-            "descrizione": "New",
-            "latitudine": 0.0,
-            "longitudine": 0.0,
+            "priorita": 2,
         },
         headers=headers,
     )
@@ -76,8 +71,8 @@ def test_list_segnalazioni(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-01-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
             "descrizione": "A",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -89,8 +84,8 @@ def test_list_segnalazioni(setup_db):
         json={
             "tipo": "violazione",
             "stato": "chiusa",
-            "priorita": "bassa",
-            "data": "2024-02-01T10:00:00",
+            "priorita": 2,
+            "data_segnalazione": "2024-02-01T10:00:00",
             "descrizione": "B",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -109,8 +104,8 @@ def test_delete_segnalazione(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-01-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
             "descrizione": "Del",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -133,8 +128,8 @@ def test_user_isolated_segnalazioni(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-01-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
             "descrizione": "U1",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -146,8 +141,8 @@ def test_user_isolated_segnalazioni(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-02-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-02-01T10:00:00",
             "descrizione": "U2",
             "latitudine": 0.0,
             "longitudine": 0.0,
@@ -159,8 +154,8 @@ def test_user_isolated_segnalazioni(setup_db):
         json={
             "tipo": "incidente",
             "stato": "aperta",
-            "priorita": "alta",
-            "data": "2024-03-01T10:00:00",
+            "priorita": 1,
+            "data_segnalazione": "2024-03-01T10:00:00",
             "descrizione": "U1B",
             "latitudine": 0.0,
             "longitudine": 0.0,


### PR DESCRIPTION
## Summary
- tweak segnalazione schema with `data_segnalazione` field
- add `SegnalazioneUpdate` model and adapt routes
- handle renamed field in CRUD
- adjust segnalazioni tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68795a8e9e388323bfff500c4a2af435