### PR TITLE
Add Segnalazioni Enum Types

### DIFF
--- a/app/models/segnalazione.py
+++ b/app/models/segnalazione.py
@@ -1,6 +1,8 @@
-from sqlalchemy import Column, String, DateTime, Float, ForeignKey, Integer
+from sqlalchemy import Column, String, DateTime, Float, ForeignKey, Integer, Enum
 from sqlalchemy.orm import relationship
+import sqlalchemy as sa
 from app.database import Base
+from app.schemas.segnalazione import TipoSegnalazione, StatoSegnalazione
 import uuid
 
 
@@ -8,8 +10,8 @@ class Segnalazione(Base):
     __tablename__ = "segnalazioni"
 
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
-    tipo = Column(String, nullable=False)
-    stato = Column(String, nullable=False)
+    tipo = Column(sa.Enum(TipoSegnalazione), nullable=False)
+    stato = Column(sa.Enum(StatoSegnalazione), nullable=False)
     priorita = Column(Integer, nullable=True)
     data_segnalazione = Column(DateTime, nullable=False)
     descrizione = Column(String, nullable=False)

--- a/migrations/versions/0008_create_segnalazioni_table.py
+++ b/migrations/versions/0008_create_segnalazioni_table.py
@@ -2,6 +2,7 @@
 
 from alembic import op
 import sqlalchemy as sa
+from app.schemas.segnalazione import TipoSegnalazione, StatoSegnalazione
 
 revision = "0008_create_segnalazioni_table"
 down_revision = "0007_add_luogo_data_to_horizontal_items"
@@ -13,10 +14,16 @@ def upgrade() -> None:
     op.create_table(
         "segnalazioni",
         sa.Column("id", sa.String(), primary_key=True),
-        sa.Column("tipo", sa.String(), nullable=False),
-        sa.Column("stato", sa.String(), nullable=False),
-        sa.Column("priorita", sa.String(), nullable=True),
-        sa.Column("data", sa.DateTime(), nullable=False),
+        sa.Column(
+            "tipo", sa.Enum(TipoSegnalazione, name="tipo_segnalazione"), nullable=False
+        ),
+        sa.Column(
+            "stato",
+            sa.Enum(StatoSegnalazione, name="stato_segnalazione"),
+            nullable=False,
+        ),
+        sa.Column("priorita", sa.Integer(), nullable=True),
+        sa.Column("data_segnalazione", sa.DateTime(), nullable=False),
         sa.Column("descrizione", sa.String(), nullable=False),
         sa.Column("latitudine", sa.Float(), nullable=True),
         sa.Column("longitudine", sa.Float(), nullable=True),
@@ -28,3 +35,9 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index("ix_segnalazioni_id", table_name="segnalazioni")
     op.drop_table("segnalazioni")
+    sa.Enum(TipoSegnalazione, name="tipo_segnalazione").drop(
+        op.get_bind(), checkfirst=True
+    )
+    sa.Enum(StatoSegnalazione, name="stato_segnalazione").drop(
+        op.get_bind(), checkfirst=True
+    )

--- a/migrations/versions/0009_convert_tipo_stato_to_enum.py
+++ b/migrations/versions/0009_convert_tipo_stato_to_enum.py
@@ -1,0 +1,58 @@
+"""convert segnalazioni tipo and stato to enum"""
+
+from alembic import op
+import sqlalchemy as sa
+from app.schemas.segnalazione import TipoSegnalazione, StatoSegnalazione
+
+revision = "0009_convert_tipo_stato_to_enum"
+down_revision = "0008_create_segnalazioni_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    tipo_enum = sa.Enum(TipoSegnalazione, name="tipo_segnalazione")
+    stato_enum = sa.Enum(StatoSegnalazione, name="stato_segnalazione")
+
+    bind = op.get_bind()
+    tipo_enum.create(bind, checkfirst=True)
+    stato_enum.create(bind, checkfirst=True)
+
+    op.alter_column(
+        "segnalazioni",
+        "tipo",
+        existing_type=sa.String(),
+        type_=tipo_enum,
+        postgresql_using="tipo::tipo_segnalazione",
+    )
+    op.alter_column(
+        "segnalazioni",
+        "stato",
+        existing_type=sa.String(),
+        type_=stato_enum,
+        postgresql_using="stato::stato_segnalazione",
+    )
+
+
+def downgrade() -> None:
+    tipo_enum = sa.Enum(TipoSegnalazione, name="tipo_segnalazione")
+    stato_enum = sa.Enum(StatoSegnalazione, name="stato_segnalazione")
+
+    op.alter_column(
+        "segnalazioni",
+        "tipo",
+        existing_type=tipo_enum,
+        type_=sa.String(),
+        postgresql_using="tipo::text",
+    )
+    op.alter_column(
+        "segnalazioni",
+        "stato",
+        existing_type=stato_enum,
+        type_=sa.String(),
+        postgresql_using="stato::text",
+    )
+
+    bind = op.get_bind()
+    tipo_enum.drop(bind, checkfirst=True)
+    stato_enum.drop(bind, checkfirst=True)


### PR DESCRIPTION
## Summary
- use Enum fields in segnalazione model
- create enums when segnalazioni table is created
- convert existing segnalazioni columns to enums

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68796010fbe0832389a5ea1f5f831ee5