### PR TITLE
Fix Segnalazione update schema

### DIFF
--- a/app/crud/segnalazione.py
+++ b/app/crud/segnalazione.py
@@ -31,7 +31,7 @@ def update_segnalazione(db: Session, segnalazione_id: str, data, user: User):
     )
     if not db_obj:
         return None
-    for key, value in data.dict().items():
+    for key, value in data.dict(exclude_unset=True).items():
         setattr(db_obj, key, value)
     db.commit()
     db.refresh(db_obj)

--- a/app/routes/segnalazioni.py
+++ b/app/routes/segnalazioni.py
@@ -44,7 +44,7 @@ def get_segnalazione_route(
 @router.put("/{segnalazione_id}", response_model=SegnalazioneResponse)
 def update_segnalazione_route(
     segnalazione_id: str,
-    data: SegnalazioneCreate,
+    data: SegnalazioneUpdate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):


### PR DESCRIPTION
## Summary
- update segnalazione PUT route to accept `SegnalazioneUpdate`
- preserve existing values in `update_segnalazione`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68796355afb48323b1d7c268e3c5533b