### PR TITLE
Clean imports and fix F401 warnings

### DIFF
--- a/app/models/segnalazione.py
+++ b/app/models/segnalazione.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, DateTime, Float, ForeignKey, Integer, Enum
+from sqlalchemy import Column, String, DateTime, Float, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 import sqlalchemy as sa
 from app.database import Base

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.dependencies import get_db
-from app.schemas.user import UserCreate, UserCredentials
+from app.schemas.user import UserCredentials
 from pydantic import BaseModel
 from google.oauth2 import id_token
 from google.auth.transport import requests

--- a/tests/test_google_calendar_module.py
+++ b/tests/test_google_calendar_module.py
@@ -2,7 +2,6 @@ import json
 from datetime import datetime
 import types
 
-import pytest
 
 from app.services import google_calendar
 


### PR DESCRIPTION
## Summary
- remove unused Enum import from segnalazione model
- drop unused UserCreate import from auth router
- delete unused pytest import in google calendar tests

## Testing
- `ruff check app tests --select F401`
- `ruff check app tests`

------
https://chatgpt.com/codex/tasks/task_e_6879635694508323aed4661fe1e404f5