### PR TITLE
Add filter-by-stato segnalazioni endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,10 +369,17 @@ Authenticated users can record incidents or violations through the
 
 - `POST /segnalazioni/` – create a new entry.
 - `GET /segnalazioni/` – list entries created by the authenticated user.
+- `GET /segnalazioni/by-stato?stato=<values>` – filter entries by one or more states.
 - `GET /segnalazioni/{id}` – retrieve a single entry by ID.
 - `PUT /segnalazioni/{id}` – update an existing entry.
 - `PATCH /segnalazioni/{id}` – partially update an entry.
 - `DELETE /segnalazioni/{id}` – remove an entry.
+
+Filter by state:
+
+```bash
+GET /segnalazioni/by-stato?stato=aperta,in%20lavorazione
+```
 
 ### Segnalazione schema
 

--- a/app/crud/segnalazione.py
+++ b/app/crud/segnalazione.py
@@ -15,6 +15,20 @@ def get_segnalazioni(db: Session, user: User):
     return db.query(Segnalazione).filter(Segnalazione.user_id == user.id).all()
 
 
+def get_segnalazioni_by_stato(db: Session, user: User, stati: list[str]):
+    """Return segnalazioni owned by ``user`` whose ``stato`` is in ``stati``."""
+    if not stati:
+        return []
+    return (
+        db.query(Segnalazione)
+        .filter(
+            Segnalazione.user_id == user.id,
+            Segnalazione.stato.in_(stati),
+        )
+        .all()
+    )
+
+
 def get_segnalazione(db: Session, segnalazione_id: str, user: User):
     return (
         db.query(Segnalazione)

--- a/app/routes/segnalazioni.py
+++ b/app/routes/segnalazioni.py
@@ -6,6 +6,7 @@ from app.schemas.segnalazione import (
     SegnalazioneCreate,
     SegnalazioneResponse,
     SegnalazioneUpdate,
+    StatoSegnalazione,
 )
 from app.crud import segnalazione as crud
 
@@ -27,6 +28,20 @@ def list_segnalazioni(
     current_user: User = Depends(get_current_user),
 ):
     return crud.get_segnalazioni(db, current_user)
+
+
+@router.get("/by-stato", response_model=list[SegnalazioneResponse])
+def list_segnalazioni_by_stato(
+    stato: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    parts = [s.strip() for s in stato.split(",") if s.strip()]
+    try:
+        stati = [StatoSegnalazione(p).value for p in parts]
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return crud.get_segnalazioni_by_stato(db, current_user, stati)
 
 
 @router.get("/{segnalazione_id}", response_model=SegnalazioneResponse)

--- a/tests/test_segnalazioni.py
+++ b/tests/test_segnalazioni.py
@@ -247,3 +247,57 @@ def test_user_isolated_segnalazioni(setup_db):
     assert len(res2.json()) == 1
     assert all(s["user_id"] == id1 for s in res1.json())
     assert all(s["user_id"] == id2 for s in res2.json())
+
+
+def test_list_by_stato(setup_db):
+    headers, _ = auth_user("filter@example.com")
+
+    client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "Piante",
+            "stato": "aperta",
+            "priorita": 1,
+            "data_segnalazione": "2024-01-01T10:00:00",
+            "descrizione": "A",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=headers,
+    )
+    client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "Piante",
+            "stato": "in lavorazione",
+            "priorita": 2,
+            "data_segnalazione": "2024-02-01T10:00:00",
+            "descrizione": "B",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=headers,
+    )
+    client.post(
+        "/segnalazioni/",
+        json={
+            "tipo": "Piante",
+            "stato": "chiusa",
+            "priorita": 3,
+            "data_segnalazione": "2024-03-01T10:00:00",
+            "descrizione": "C",
+            "latitudine": 0.0,
+            "longitudine": 0.0,
+        },
+        headers=headers,
+    )
+
+    res = client.get(
+        "/segnalazioni/by-stato",
+        params={"stato": "aperta,in lavorazione"},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 2
+    assert {s["stato"] for s in data} == {"aperta", "in lavorazione"}


### PR DESCRIPTION
## Summary
- add CRUD helper to filter segnalazioni by stato
- expose new `/segnalazioni/by-stato` route
- document filtering route in README
- test segnalazioni filtering by stato

## Testing
- `pytest -k segnalazioni -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687a61705e1c8323be6b038ba24a28ff