### PR TITLE
Add segnaletica orizzontale import and pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,23 @@ curl -X POST http://localhost:8000/piani-orizzontali/{piano_id}/items \
 }
 ```
 
+## Segnaletica orizzontale endpoints
+
+These routes manage simple horizontal signage records and allow importing from Excel.
+
+- `POST /segnaletica-orizzontale/` – create an entry.
+- `GET /segnaletica-orizzontale/` – list entries.
+- `PUT /segnaletica-orizzontale/{id}` – update an entry.
+- `DELETE /segnaletica-orizzontale/{id}` – remove an entry.
+- `POST /segnaletica-orizzontale/import` – import an Excel file and get a PDF summary.
+
+Example:
+
+```bash
+curl -X POST -F "file=@piano.xlsx" \
+  http://localhost:8000/segnaletica-orizzontale/import -o piano.pdf
+```
+
 ## Segnalazioni endpoints
 
 Authenticated users can record incidents or violations through the

--- a/app/crud/segnaletica_orizzontale.py
+++ b/app/crud/segnaletica_orizzontale.py
@@ -1,0 +1,38 @@
+from sqlalchemy.orm import Session
+from app.models.segnaletica_orizzontale import SegnaleticaOrizzontale
+
+
+def create_segnaletica_orizzontale(db: Session, data):
+    db_obj = SegnaleticaOrizzontale(**data.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_segnaletica_orizzontale(db: Session, search: str | None = None, anno: int | None = None):
+    query = db.query(SegnaleticaOrizzontale)
+    if search:
+        query = query.filter(SegnaleticaOrizzontale.descrizione.ilike(f"%{search}%"))
+    if anno is not None:
+        query = query.filter(SegnaleticaOrizzontale.anno == anno)
+    return query.all()
+
+
+def update_segnaletica_orizzontale(db: Session, so_id: str, data):
+    db_obj = db.query(SegnaleticaOrizzontale).filter(SegnaleticaOrizzontale.id == so_id).first()
+    if not db_obj:
+        return None
+    for key, value in data.dict().items():
+        setattr(db_obj, key, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def delete_segnaletica_orizzontale(db: Session, so_id: str):
+    db_obj = db.query(SegnaleticaOrizzontale).filter(SegnaleticaOrizzontale.id == so_id).first()
+    if db_obj:
+        db.delete(db_obj)
+        db.commit()
+    return db_obj

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from app.routes import (
     segnaletica_temporanea,
     segnaletica_verticale,
     piani_orizzontali,
+    segnaletica_orizzontale,
     segnalazioni,
 )
 from app.routes.orari import router as orari_router
@@ -57,6 +58,7 @@ app.include_router(segnalazioni.router)
 app.include_router(segnaletica_temporanea.router)
 app.include_router(segnaletica_verticale.router)
 app.include_router(piani_orizzontali.router)
+app.include_router(segnaletica_orizzontale.router)
 app.include_router(dashboard.router)
 app.include_router(health.router)
 app.include_router(orari_router)

--- a/app/models/segnaletica_orizzontale.py
+++ b/app/models/segnaletica_orizzontale.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, String, Integer
+from app.database import Base
+import uuid
+
+
+class SegnaleticaOrizzontale(Base):
+    __tablename__ = "segnaletica_orizzontale"
+
+    id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
+    azienda = Column(String, nullable=False)
+    anno = Column(Integer, nullable=False)
+    descrizione = Column(String, nullable=False)

--- a/app/routes/segnaletica_orizzontale.py
+++ b/app/routes/segnaletica_orizzontale.py
@@ -1,0 +1,81 @@
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, BackgroundTasks
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+import tempfile
+import os
+from datetime import date
+
+from app.dependencies import get_db
+from app.schemas.segnaletica_orizzontale import (
+    SegnaleticaOrizzontaleCreate,
+    SegnaleticaOrizzontaleResponse,
+)
+from app.crud import segnaletica_orizzontale as crud
+from app.services.segnaletica_orizzontale_import import parse_excel
+from app.services.segnaletica_orizzontale_pdf import build_segnaletica_orizzontale_pdf
+
+router = APIRouter(prefix="/segnaletica-orizzontale", tags=["Segnaletica Orizzontale"])
+
+
+@router.post("/", response_model=SegnaleticaOrizzontaleResponse)
+def create_segnaletica_orizzontale_route(
+    data: SegnaleticaOrizzontaleCreate, db: Session = Depends(get_db)
+):
+    return crud.create_segnaletica_orizzontale(db, data)
+
+
+@router.get("/", response_model=list[SegnaleticaOrizzontaleResponse])
+def list_segnaletica_orizzontale(
+    search: str | None = None,
+    anno: int | None = None,
+    db: Session = Depends(get_db),
+):
+    return crud.get_segnaletica_orizzontale(db, search=search, anno=anno)
+
+
+@router.put("/{so_id}", response_model=SegnaleticaOrizzontaleResponse)
+def update_segnaletica_orizzontale_route(
+    so_id: str, data: SegnaleticaOrizzontaleCreate, db: Session = Depends(get_db)
+):
+    db_obj = crud.update_segnaletica_orizzontale(db, so_id, data)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnaletica orizzontale not found")
+    return db_obj
+
+
+@router.delete("/{so_id}")
+def delete_segnaletica_orizzontale_route(so_id: str, db: Session = Depends(get_db)):
+    db_obj = crud.delete_segnaletica_orizzontale(db, so_id)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Segnaletica orizzontale not found")
+    return {"ok": True}
+
+
+@router.post("/import")
+async def import_segnaletica_orizzontale(
+    file: UploadFile,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
+            tmp.write(await file.read())
+            tmp_path = tmp.name
+        rows = parse_excel(tmp_path)
+        descrizioni = []
+        azienda = rows[0]["azienda"] if rows else ""
+        for payload in rows:
+            crud.create_segnaletica_orizzontale(db, SegnaleticaOrizzontaleCreate(**payload))
+            descrizioni.append(payload["descrizione"])
+        pdf_path, html_path = build_segnaletica_orizzontale_pdf(descrizioni, azienda, date.today().year)
+        background_tasks.add_task(os.remove, pdf_path)
+        background_tasks.add_task(os.remove, html_path)
+        return FileResponse(pdf_path, filename="segnaletica_orizzontale.pdf")
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.remove(tmp_path)

--- a/app/schemas/segnaletica_orizzontale.py
+++ b/app/schemas/segnaletica_orizzontale.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+
+class SegnaleticaOrizzontaleCreate(BaseModel):
+    azienda: str
+    descrizione: str
+    anno: int
+
+
+class SegnaleticaOrizzontaleResponse(SegnaleticaOrizzontaleCreate):
+    id: str
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/services/segnaletica_orizzontale_import.py
+++ b/app/services/segnaletica_orizzontale_import.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from datetime import date
+from typing import Any, Dict, List
+from fastapi import HTTPException
+
+
+def parse_excel(path: str) -> List[Dict[str, Any]]:
+    df = pd.read_excel(path)
+    lower_cols = {c.lower(): c for c in df.columns}
+    required = {"azienda", "descrizione"}
+    missing = required - set(lower_cols.keys())
+    if missing:
+        raise HTTPException(status_code=400, detail=f"Missing columns: {missing}")
+
+    azienda_col = lower_cols["azienda"]
+    descr_col = lower_cols["descrizione"]
+
+    rows: List[Dict[str, Any]] = []
+    for idx, row in df.iterrows():
+        azienda = row.get(azienda_col)
+        descr = row.get(descr_col)
+        if pd.isna(azienda) or str(azienda).strip() == "":
+            raise HTTPException(status_code=400, detail=f"Row {idx+2}: Missing azienda")
+        if pd.isna(descr) or str(descr).strip() == "":
+            raise HTTPException(status_code=400, detail=f"Row {idx+2}: Missing descrizione")
+        rows.append(
+            {
+                "azienda": str(azienda).strip(),
+                "descrizione": str(descr).strip(),
+                "anno": date.today().year,
+            }
+        )
+    return rows

--- a/app/services/segnaletica_orizzontale_pdf.py
+++ b/app/services/segnaletica_orizzontale_pdf.py
@@ -1,0 +1,43 @@
+from typing import List, Tuple
+from weasyprint import HTML
+import tempfile
+import html
+
+
+def build_segnaletica_orizzontale_pdf(descrizioni: List[str], azienda: str, year: int) -> Tuple[str, str]:
+    styles = """
+    <style>
+    @page { size: A4; margin: 10mm; }
+    body { font-family: Aptos, sans-serif; font-size: 10pt; }
+    table { border-collapse: collapse; width: 100%; page-break-inside: avoid; }
+    th, td { border: 1px solid #000; padding: 4px; text-align: left; }
+    </style>
+    """
+
+    rows_html = "".join(f"<tr><td>{html.escape(d)}</td></tr>" for d in descrizioni)
+
+    html_content = f"""
+    <html>
+    <head>
+    <meta charset='utf-8'>
+    {styles}
+    </head>
+    <body>
+    <h1 style='text-align:center;'>Piano Segnaletica Orizzontale Anno {year}</h1>
+    <h2 style='text-align:center;'>{html.escape(azienda)}</h2>
+    <table>
+    <tr><th>Descrizione</th></tr>
+    {rows_html}
+    </table>
+    </body>
+    </html>
+    """
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as tmp_html:
+        tmp_html.write(html_content.encode("utf-8"))
+        html_path = tmp_html.name
+
+    pdf_path = html_path.replace(".html", ".pdf")
+    HTML(filename=html_path).write_pdf(pdf_path)
+
+    return pdf_path, html_path

--- a/migrations/versions/0010_create_segnaletica_orizzontale.py
+++ b/migrations/versions/0010_create_segnaletica_orizzontale.py
@@ -1,0 +1,27 @@
+"""create segnaletica orizzontale table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0010_create_segnaletica_orizzontale"
+down_revision = "0009_update_segnalazioni_schema"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "segnaletica_orizzontale",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("azienda", sa.String(), nullable=False),
+        sa.Column("anno", sa.Integer(), nullable=False),
+        sa.Column("descrizione", sa.String(), nullable=False),
+    )
+    op.create_index(
+        "ix_segnaletica_orizzontale_id", "segnaletica_orizzontale", ["id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_segnaletica_orizzontale_id", table_name="segnaletica_orizzontale")
+    op.drop_table("segnaletica_orizzontale")

--- a/tests/test_segnaletica_orizzontale.py
+++ b/tests/test_segnaletica_orizzontale.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+from datetime import date
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+import os
+import pandas as pd
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_import_excel_creates_records_and_pdf(setup_db, tmp_path):
+    df = pd.DataFrame([
+        {"azienda": "ACME", "descrizione": "Linea"},
+        {"azienda": "ACME", "descrizione": "Stop"},
+    ])
+    xlsx = tmp_path / "segna.xlsx"
+    df.to_excel(xlsx, index=False)
+
+    captured = {}
+    real_build = __import__(
+        "app.services.segnaletica_orizzontale_pdf",
+        fromlist=["build_segnaletica_orizzontale_pdf"],
+    ).build_segnaletica_orizzontale_pdf
+
+    def fake_write_pdf(self, target, *args, **kwargs):
+        Path(target).write_bytes(b"%PDF-1.4 fake")
+
+    def capture(descrizioni, azienda, year):
+        pdf, html = real_build(descrizioni, azienda, year)
+        captured["pdf"] = pdf
+        captured["html"] = html
+        captured["html_text"] = Path(html).read_text()
+        captured["descrizioni"] = descrizioni
+        captured["azienda"] = azienda
+        captured["year"] = year
+        return pdf, html
+
+    with patch("weasyprint.HTML.write_pdf", side_effect=fake_write_pdf):
+        with patch(
+            "app.routes.segnaletica_orizzontale.build_segnaletica_orizzontale_pdf",
+            side_effect=capture,
+        ):
+            with open(xlsx, "rb") as fh:
+                res = client.post(
+                    "/segnaletica-orizzontale/import",
+                    files={
+                        "file": (
+                            "segna.xlsx",
+                            fh,
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        )
+                    },
+                )
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "application/pdf"
+
+    list_res = client.get("/segnaletica-orizzontale/")
+    records = list_res.json()
+    assert len(records) == 2
+    assert all(r["anno"] == date.today().year for r in records)
+
+    assert captured["descrizioni"] == ["Linea", "Stop"]
+    assert f"Piano Segnaletica Orizzontale Anno {date.today().year}" in captured["html_text"]
+    assert "ACME" in captured["html_text"]
+    assert "Linea" in captured["html_text"]
+    assert "Stop" in captured["html_text"]
+    assert not os.path.exists(captured["pdf"])
+    assert not os.path.exists(captured["html"])
+
+
+def test_import_temp_files_removed(setup_db, tmp_path):
+    captured = {}
+
+    def fake_parse(path):
+        captured["xlsx"] = path
+        return [{"azienda": "A", "descrizione": "B", "anno": date.today().year}]
+
+    def fake_build(rows, azienda, year):
+        pdf = tmp_path / "out.pdf"
+        html = tmp_path / "out.html"
+        pdf.write_bytes(b"%PDF-1.4 fake")
+        html.write_text("html")
+        captured["pdf"] = str(pdf)
+        captured["html"] = str(html)
+        return str(pdf), str(html)
+
+    with patch("app.routes.segnaletica_orizzontale.parse_excel", side_effect=fake_parse):
+        with patch(
+            "app.routes.segnaletica_orizzontale.build_segnaletica_orizzontale_pdf",
+            side_effect=fake_build,
+        ):
+            dummy = tmp_path / "s.xlsx"
+            dummy.write_bytes(b"data")
+            with open(dummy, "rb") as fh:
+                res = client.post(
+                    "/segnaletica-orizzontale/import",
+                    files={
+                        "file": (
+                            "s.xlsx",
+                            fh,
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        )
+                    },
+                )
+    assert res.status_code == 200
+    assert not os.path.exists(captured["xlsx"])
+    assert not os.path.exists(captured["pdf"])
+    assert not os.path.exists(captured["html"])


### PR DESCRIPTION
## Summary
- add SegnaleticaOrizzontale model and migration
- CRUD helpers and API routes with Excel import
- parse Excel files and build PDF summaries
- document the new endpoints
- tests for import, PDF contents and cleanup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687a64a202f08323857c2f36dda442d4