### PR TITLE
Fix segnalazione creation

### DIFF
--- a/app/crud/segnalazione.py
+++ b/app/crud/segnalazione.py
@@ -4,11 +4,37 @@ from app.models.user import User
 
 
 def create_segnalazione(db: Session, data, user: User):
-    db_obj = Segnalazione(**data.dict(), user_id=user.id)
-    db.add(db_obj)
+    tipo_val = getattr(data.tipo, "value", data.tipo)
+    stato_val = getattr(data.stato, "value", data.stato)
+    stato_val = stato_val.lower()
+
+    mapping_tipo = {
+        "piante": "Piante",
+        "danneggiamenti": "Danneggiamenti",
+        "reati": "Reati",
+        "animali": "Animali",
+        "altro": "Altro",
+    }
+
+    tipo_val = mapping_tipo.get(tipo_val.lower(), tipo_val)
+
+    obj = Segnalazione(
+        tipo=tipo_val,
+        stato=stato_val,
+        priorita=data.priorita,
+        data_segnalazione=data.data_segnalazione,
+        descrizione=data.descrizione,
+        latitudine=data.latitudine,
+        longitudine=data.longitudine,
+        user_id=user.id,
+    )
+
+    print("DEBUG INSERT:", obj.tipo, obj.stato)
+
+    db.add(obj)
     db.commit()
-    db.refresh(db_obj)
-    return db_obj
+    db.refresh(obj)
+    return obj
 
 
 def get_segnalazioni(db: Session, user: User):

--- a/migrations/versions/0011_update_segnalazioni_stato_check.py
+++ b/migrations/versions/0011_update_segnalazioni_stato_check.py
@@ -1,0 +1,25 @@
+"""update segnalazioni stato check constraint"""
+
+from alembic import op
+
+revision = "0011_update_segnalazioni_stato_check"
+down_revision = "0010_create_segnaletica_orizzontale"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE segnalazioni DROP CONSTRAINT IF EXISTS segnalazioni_stato_check;"
+    )
+    op.execute(
+        "ALTER TABLE segnalazioni "
+        "ADD CONSTRAINT segnalazioni_stato_check "
+        "CHECK (lower(stato) IN ('aperta','in lavorazione','chiusa'));"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE segnalazioni DROP CONSTRAINT IF EXISTS segnalazioni_stato_check;"
+    )


### PR DESCRIPTION
## Summary
- normalise `tipo` and `stato` values in segnalazione CRUD
- add debug logging of inserted values
- add alembic migration to enforce lowercase stato check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687aca7ffe588323af5da14caec632d4