### PR TITLE
Fix enum value handling in segnalazioni

### DIFF
--- a/app/models/segnalazione.py
+++ b/app/models/segnalazione.py
@@ -10,8 +10,8 @@ class Segnalazione(Base):
     __tablename__ = "segnalazioni"
 
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
-    tipo = Column(sa.Enum(TipoSegnalazione), nullable=False)
-    stato = Column(sa.Enum(StatoSegnalazione), nullable=False)
+    tipo = Column(String(30), nullable=False)
+    stato = Column(String(30), nullable=False)
     priorita = Column(Integer, nullable=True)
     data_segnalazione = Column(DateTime, nullable=False)
     descrizione = Column(String, nullable=False)

--- a/migrations/versions/0012_convert_segnalazioni_enum_to_string.py
+++ b/migrations/versions/0012_convert_segnalazioni_enum_to_string.py
@@ -1,0 +1,71 @@
+"""convert segnalazioni columns tipo and stato to string"""
+
+from alembic import op
+import sqlalchemy as sa
+from app.schemas.segnalazione import TipoSegnalazione, StatoSegnalazione
+
+revision = "0012_convert_segnalazioni_enum_to_string"
+down_revision = "0011_update_segnalazioni_stato_check"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    tipo_enum = sa.Enum(TipoSegnalazione, name="tiposegnalazione")
+    stato_enum = sa.Enum(StatoSegnalazione, name="statosegnalazione")
+
+    op.alter_column(
+        "segnalazioni",
+        "tipo",
+        existing_type=tipo_enum,
+        type_=sa.String(length=30),
+        postgresql_using="tipo::text",
+    )
+    op.alter_column(
+        "segnalazioni",
+        "stato",
+        existing_type=stato_enum,
+        type_=sa.String(length=30),
+        postgresql_using="stato::text",
+    )
+
+    bind = op.get_bind()
+    tipo_enum.drop(bind, checkfirst=True)
+    stato_enum.drop(bind, checkfirst=True)
+
+    op.execute(
+        "ALTER TABLE segnalazioni DROP CONSTRAINT IF EXISTS segnalazioni_stato_check;"
+    )
+    op.execute(
+        "ALTER TABLE segnalazioni ADD CONSTRAINT segnalazioni_stato_check CHECK (lower(stato) IN ('aperta','in lavorazione','chiusa'));"
+    )
+
+
+def downgrade() -> None:
+    tipo_enum = sa.Enum(TipoSegnalazione, name="tiposegnalazione")
+    stato_enum = sa.Enum(StatoSegnalazione, name="statosegnalazione")
+
+    tipo_enum.create(op.get_bind(), checkfirst=True)
+    stato_enum.create(op.get_bind(), checkfirst=True)
+
+    op.alter_column(
+        "segnalazioni",
+        "tipo",
+        existing_type=sa.String(length=30),
+        type_=tipo_enum,
+        postgresql_using="tipo::tiposegnalazione",
+    )
+    op.alter_column(
+        "segnalazioni",
+        "stato",
+        existing_type=sa.String(length=30),
+        type_=stato_enum,
+        postgresql_using="stato::statosegnalazione",
+    )
+
+    op.execute(
+        "ALTER TABLE segnalazioni DROP CONSTRAINT IF EXISTS segnalazioni_stato_check;"
+    )
+    op.execute(
+        "ALTER TABLE segnalazioni ADD CONSTRAINT segnalazioni_stato_check CHECK (lower(stato) IN ('aperta','in lavorazione','chiusa'));"
+    )


### PR DESCRIPTION
## Summary
- normalize enum values for segnalazioni CRUD operations
- store `tipo` and `stato` as strings
- add Alembic migration converting enum columns to string columns

## Testing
- `pytest -q tests/test_segnalazioni.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687acde4a974832392422e3a292685d9