### PR TITLE
Add signage years endpoint

### DIFF
--- a/app/routes/inventario.py
+++ b/app/routes/inventario.py
@@ -4,9 +4,18 @@ from sqlalchemy.orm import Session
 import os
 
 from app.dependencies import get_db
-from app.services.signage_horizontal import build_signage_horizontal_pdf
+from app.services.signage_horizontal import (
+    build_signage_horizontal_pdf,
+    get_years,
+)
 
 router = APIRouter(prefix="/inventario", tags=["Inventario"])
+
+
+@router.get("/signage-horizontal/years", response_model=list[int])
+def signage_horizontal_years(db: Session = Depends(get_db)):
+    """List distinct years for which horizontal signage plans exist."""
+    return get_years(db)
 
 
 @router.get("/signage-horizontal/pdf")

--- a/app/services/signage_horizontal.py
+++ b/app/services/signage_horizontal.py
@@ -36,3 +36,15 @@ def build_signage_horizontal_pdf(db: Session, year: int) -> Tuple[str, str]:
     """Build a PDF inventory report for SegnaleticaOrizzontaleItem entries."""
     items = aggregate_items(db, year)
     return build_inventory_pdf(items, year)
+
+
+def get_years(db: Session) -> List[int]:
+    """Return all distinct ``anno`` values from ``PianoSegnaleticaOrizzontale``."""
+    rows = (
+        db.query(PianoSegnaleticaOrizzontale.anno)
+        .filter(PianoSegnaleticaOrizzontale.anno.isnot(None))
+        .distinct()
+        .order_by(PianoSegnaleticaOrizzontale.anno)
+        .all()
+    )
+    return [int(row[0]) for row in rows]

--- a/tests/test_signage_horizontal_pdf.py
+++ b/tests/test_signage_horizontal_pdf.py
@@ -56,3 +56,13 @@ def test_signage_horizontal_pdf_aggregates_items(setup_db, tmp_path):
     assert "5" in captured["html_text"]
     assert not os.path.exists(captured["pdf"])
     assert not os.path.exists(captured["html"])
+
+
+def test_signage_horizontal_years(setup_db):
+    create_piano("First", 2020)
+    create_piano("Second", 2023)
+    create_piano("Third", 2023)
+
+    res = client.get("/inventario/signage-horizontal/years")
+    assert res.status_code == 200
+    assert res.json() == [2020, 2023]


### PR DESCRIPTION
## Summary
- add `get_years` helper in `signage_horizontal` service
- expose `/inventario/signage-horizontal/years` route
- test the new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687b84d0bea08323ba5f63588906d8e2