### PR TITLE
Add signage inventory endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,10 @@ The `/inventario/signage-horizontal/pdf` route returns a PDF listing of
 horizontal signage for the specified year. The `year` query parameter is
 required and must be an integer.
 
+Use `/inventario/signage-horizontal/?year=<YEAR>` to obtain the raw JSON
+counts instead of a PDF. The response is a list of objects with `name` and
+`count` fields.
+
 Example:
 
 ```bash

--- a/app/routes/inventario.py
+++ b/app/routes/inventario.py
@@ -7,7 +7,9 @@ from app.dependencies import get_db
 from app.services.signage_horizontal import (
     build_signage_horizontal_pdf,
     get_years,
+    aggregate_items,
 )
+from app.schemas.piano_segnaletica_orizzontale import SignageInventoryItem
 
 router = APIRouter(prefix="/inventario", tags=["Inventario"])
 
@@ -29,3 +31,12 @@ def signage_horizontal_pdf(
     background_tasks.add_task(os.remove, html_path)
     filename = f"signage_horizontal_{year}.pdf"
     return FileResponse(pdf_path, filename=filename)
+
+
+@router.get(
+    "/signage-horizontal/",
+    response_model=list[SignageInventoryItem],
+)
+def signage_horizontal_items(year: int, db: Session = Depends(get_db)):
+    """Return aggregated signage items for the given year."""
+    return aggregate_items(db, year)

--- a/app/schemas/piano_segnaletica_orizzontale.py
+++ b/app/schemas/piano_segnaletica_orizzontale.py
@@ -38,3 +38,10 @@ class PianoSegnaleticaOrizzontaleResponse(PianoSegnaleticaOrizzontaleCreate):
     model_config = {
         "from_attributes": True,
     }
+
+
+class SignageInventoryItem(BaseModel):
+    """Aggregated inventory entry used by inventory endpoints."""
+
+    name: str
+    count: int


### PR DESCRIPTION
## Summary
- add `SignageInventoryItem` schema
- support returning aggregated signage data
- document new inventory route
- test horizontal signage inventory listing

## Testing
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687cb99075788323965fe99b8520a9a9