### PR TITLE
Fix signage import

### DIFF
--- a/app/routes/segnaletica_orizzontale.py
+++ b/app/routes/segnaletica_orizzontale.py
@@ -21,6 +21,8 @@ router = APIRouter(prefix="/segnaletica-orizzontale", tags=["Segnaletica Orizzon
 def create_segnaletica_orizzontale_route(
     data: SegnaleticaOrizzontaleCreate, db: Session = Depends(get_db)
 ):
+    if data.anno is None:
+        data.anno = date.today().year
     return crud.create_segnaletica_orizzontale(db, data)
 
 
@@ -66,7 +68,9 @@ async def import_segnaletica_orizzontale(
         descrizioni = []
         azienda = rows[0]["azienda"] if rows else ""
         for payload in rows:
-            crud.create_segnaletica_orizzontale(db, SegnaleticaOrizzontaleCreate(**payload))
+            create_segnaletica_orizzontale_route(
+                SegnaleticaOrizzontaleCreate(**payload), db
+            )
             descrizioni.append(payload["descrizione"])
         pdf_path, html_path = build_segnaletica_orizzontale_pdf(descrizioni, azienda, date.today().year)
         background_tasks.add_task(os.remove, pdf_path)

--- a/app/schemas/segnaletica_orizzontale.py
+++ b/app/schemas/segnaletica_orizzontale.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 class SegnaleticaOrizzontaleCreate(BaseModel):
     azienda: str
     descrizione: str
-    anno: int
+    anno: int | None = None
 
 
 class SegnaleticaOrizzontaleResponse(SegnaleticaOrizzontaleCreate):

--- a/app/services/segnaletica_orizzontale_import.py
+++ b/app/services/segnaletica_orizzontale_import.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from datetime import date
 from typing import Any, Dict, List
 from fastapi import HTTPException
 
@@ -27,7 +26,6 @@ def parse_excel(path: str) -> List[Dict[str, Any]]:
             {
                 "azienda": str(azienda).strip(),
                 "descrizione": str(descr).strip(),
-                "anno": date.today().year,
             }
         )
     return rows

--- a/tests/test_segnaletica_orizzontale.py
+++ b/tests/test_segnaletica_orizzontale.py
@@ -77,7 +77,7 @@ def test_import_temp_files_removed(setup_db, tmp_path):
 
     def fake_parse(path):
         captured["xlsx"] = path
-        return [{"azienda": "A", "descrizione": "B", "anno": date.today().year}]
+        return [{"azienda": "A", "descrizione": "B"}]
 
     def fake_build(rows, azienda, year):
         pdf = tmp_path / "out.pdf"

--- a/tests/test_segnaletica_orizzontale_import.py
+++ b/tests/test_segnaletica_orizzontale_import.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import pytest
+from fastapi import HTTPException
+from app.services.segnaletica_orizzontale_import import parse_excel
+
+
+def test_parse_excel_valid(tmp_path):
+    df = pd.DataFrame([
+        {"azienda": "ACME", "descrizione": "Linea"},
+        {"azienda": "ACME", "descrizione": "Stop"},
+    ])
+    xls = tmp_path / "segna.xlsx"
+    df.to_excel(xls, index=False)
+
+    rows = parse_excel(str(xls))
+
+    assert rows == [
+        {"azienda": "ACME", "descrizione": "Linea"},
+        {"azienda": "ACME", "descrizione": "Stop"},
+    ]
+
+
+def test_parse_excel_missing_column(tmp_path):
+    df = pd.DataFrame([
+        {"azienda": "ACME"},
+    ])
+    xls = tmp_path / "bad.xlsx"
+    df.to_excel(xls, index=False)
+
+    with pytest.raises(HTTPException) as exc:
+        parse_excel(str(xls))
+
+    assert exc.value.status_code == 400
+    assert "Missing columns" in exc.value.detail


### PR DESCRIPTION
## Summary
- don't add `anno` in signage excel parser
- default year when creating new signage
- update `/segnaletica-orizzontale/import` to use helper
- test signage excel parsing and import

## Testing
- `pytest -q tests/test_segnaletica_orizzontale_import.py::test_parse_excel_valid -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687cbe459998832396fdc3b380b8f514