### PR TITLE
Enhance signage horizontal CRUD

### DIFF
--- a/app/crud/segnaletica_orizzontale.py
+++ b/app/crud/segnaletica_orizzontale.py
@@ -1,29 +1,48 @@
+from datetime import date
 from sqlalchemy.orm import Session
 from app.models.segnaletica_orizzontale import SegnaleticaOrizzontale
 
 
 def create_segnaletica_orizzontale(db: Session, data):
-    db_obj = SegnaleticaOrizzontale(**data.dict())
+    payload = data.dict()
+    payload["anno"] = date.today().year
+    db_obj = SegnaleticaOrizzontale(**payload)
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)
     return db_obj
 
 
-def get_segnaletica_orizzontale(db: Session, search: str | None = None, anno: int | None = None):
+def get_segnaletica_orizzontale(
+    db: Session, search: str | None = None, year: int | None = None
+):
     query = db.query(SegnaleticaOrizzontale)
     if search:
-        query = query.filter(SegnaleticaOrizzontale.descrizione.ilike(f"%{search}%"))
-    if anno is not None:
-        query = query.filter(SegnaleticaOrizzontale.anno == anno)
+        query = query.filter(
+            SegnaleticaOrizzontale.descrizione.ilike(f"%{search}%")
+        )
+    if year is not None:
+        query = query.filter(SegnaleticaOrizzontale.anno == year)
     return query.all()
+
+
+def get_years(db: Session) -> list[int]:
+    rows = (
+        db.query(SegnaleticaOrizzontale.anno)
+        .filter(SegnaleticaOrizzontale.anno.isnot(None))
+        .distinct()
+        .order_by(SegnaleticaOrizzontale.anno)
+        .all()
+    )
+    return [int(row[0]) for row in rows]
 
 
 def update_segnaletica_orizzontale(db: Session, so_id: str, data):
     db_obj = db.query(SegnaleticaOrizzontale).filter(SegnaleticaOrizzontale.id == so_id).first()
     if not db_obj:
         return None
-    for key, value in data.dict().items():
+    payload = data.model_dump(mode="json", exclude_unset=True)
+    for key, value in payload.items():
         setattr(db_obj, key, value)
     db.commit()
     db.refresh(db_obj)

--- a/app/routes/segnaletica_orizzontale.py
+++ b/app/routes/segnaletica_orizzontale.py
@@ -9,6 +9,7 @@ from app.dependencies import get_db
 from app.schemas.segnaletica_orizzontale import (
     SegnaleticaOrizzontaleCreate,
     SegnaleticaOrizzontaleResponse,
+    SegnaleticaOrizzontaleUpdate,
 )
 from app.crud import segnaletica_orizzontale as crud
 from app.services.segnaletica_orizzontale_import import parse_excel
@@ -27,15 +28,15 @@ def create_segnaletica_orizzontale_route(
 @router.get("/", response_model=list[SegnaleticaOrizzontaleResponse])
 def list_segnaletica_orizzontale(
     search: str | None = None,
-    anno: int | None = None,
+    year: int | None = None,
     db: Session = Depends(get_db),
 ):
-    return crud.get_segnaletica_orizzontale(db, search=search, anno=anno)
+    return crud.get_segnaletica_orizzontale(db, search=search, year=year)
 
 
 @router.put("/{so_id}", response_model=SegnaleticaOrizzontaleResponse)
 def update_segnaletica_orizzontale_route(
-    so_id: str, data: SegnaleticaOrizzontaleCreate, db: Session = Depends(get_db)
+    so_id: str, data: SegnaleticaOrizzontaleUpdate, db: Session = Depends(get_db)
 ):
     db_obj = crud.update_segnaletica_orizzontale(db, so_id, data)
     if not db_obj:

--- a/app/schemas/segnaletica_orizzontale.py
+++ b/app/schemas/segnaletica_orizzontale.py
@@ -7,6 +7,12 @@ class SegnaleticaOrizzontaleCreate(BaseModel):
     anno: int
 
 
+class SegnaleticaOrizzontaleUpdate(BaseModel):
+    azienda: str | None = None
+    descrizione: str | None = None
+    anno: int | None = None
+
+
 class SegnaleticaOrizzontaleResponse(SegnaleticaOrizzontaleCreate):
     id: str
 


### PR DESCRIPTION
## Summary
- auto-fill `anno` on signage horizontal creation
- allow filtering by year and query available years
- update horizontal signage routes to use new update schema

## Testing
- `pytest -q tests/test_segnaletica_orizzontale.py::test_import_excel_creates_records_and_pdf -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687cbe4277a083239c4cff9a1ff261ae