### PR TITLE
Add PDF plan generator

### DIFF
--- a/app/routes/signage_horizontal.py
+++ b/app/routes/signage_horizontal.py
@@ -9,7 +9,9 @@ from app.schemas.segnaletica_orizzontale import (
     SegnaleticaOrizzontaleResponse,
 )
 from app.crud import segnaletica_orizzontale as crud
-from app.services.signage_horizontal import build_signage_horizontal_pdf
+from app.services.segnaletica_orizzontale_pdf import (
+    build_segnaletica_orizzontale_pdf,
+)
 
 router = APIRouter(prefix="/inventario/signage-horizontal", tags=["Inventario"])
 
@@ -53,8 +55,8 @@ def signage_horizontal_pdf(
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
-    """Return an inventory PDF for the given ``year``."""
-    pdf_path, html_path = build_signage_horizontal_pdf(db, year)
+    """Return a signage plan PDF for the given ``year``."""
+    pdf_path, html_path = build_segnaletica_orizzontale_pdf(db, year)
     background_tasks.add_task(os.remove, pdf_path)
     background_tasks.add_task(os.remove, html_path)
     filename = f"signage_horizontal_{year}.pdf"

--- a/app/services/segnaletica_orizzontale_pdf.py
+++ b/app/services/segnaletica_orizzontale_pdf.py
@@ -1,14 +1,28 @@
-from typing import List, Tuple
+from typing import Tuple
+from sqlalchemy.orm import Session
 from weasyprint import HTML
 import tempfile
 import html
 import os
 from fastapi import HTTPException
 
+from app.models.segnaletica_orizzontale import SegnaleticaOrizzontale
 
-def build_segnaletica_orizzontale_pdf(
-    descrizioni: List[str], azienda: str, year: int
-) -> Tuple[str, str]:
+
+def build_segnaletica_orizzontale_pdf(db: Session, year: int) -> Tuple[str, str]:
+    """Create a PDF "piano" for horizontal signage entries of ``year``."""
+
+    rows = (
+        db.query(SegnaleticaOrizzontale.azienda, SegnaleticaOrizzontale.descrizione)
+        .filter(SegnaleticaOrizzontale.anno == year)
+        .order_by(SegnaleticaOrizzontale.descrizione)
+        .all()
+    )
+
+    descrizioni = [r.descrizione for r in rows]
+    aziende = {r.azienda for r in rows}
+    azienda = aziende.pop() if len(aziende) == 1 else ""
+
     styles = """
     <style>
     @page { size: A4; margin: 10mm; }
@@ -25,6 +39,9 @@ def build_segnaletica_orizzontale_pdf(
         raise HTTPException(status_code=500, detail="Logo file missing")
 
     rows_html = "".join(f"<tr><td>{html.escape(d)}</td></tr>" for d in descrizioni)
+    azienda_html = (
+        f"<h2 style='text-align:center;'>{html.escape(azienda)}</h2>" if azienda else ""
+    )
 
     html_content = f"""
     <html>
@@ -37,7 +54,7 @@ def build_segnaletica_orizzontale_pdf(
         <img src='{logo_path}' alt='logo' style='width:70px; margin-right:8px;' />
         <h1 style='text-align:center; flex-grow:1; margin:0;'>Piano Segnaletica Orizzontale Anno {year}</h1>
     </div>
-    <h2 style='text-align:center;'>{html.escape(azienda)}</h2>
+    {azienda_html}
     <table>
     <tr><th>Lavori da eseguire</th></tr>
     {rows_html}


### PR DESCRIPTION
## Summary
- generate signage plan PDFs for a given year
- wire up the plan PDF endpoint
- test plan PDF logic

## Testing
- `python -m py_compile app/services/segnaletica_orizzontale_pdf.py tests/test_segnaletica_orizzontale.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687cc124cf4483238bf23d0deccff09c