### PR TITLE
Update signage horizontal helpers

### DIFF
--- a/app/crud/segnaletica_orizzontale.py
+++ b/app/crud/segnaletica_orizzontale.py
@@ -1,9 +1,12 @@
+from datetime import date
 from sqlalchemy.orm import Session
 from app.models.segnaletica_orizzontale import SegnaleticaOrizzontale
 
 
 def create_segnaletica_orizzontale(db: Session, data):
-    db_obj = SegnaleticaOrizzontale(**data.dict())
+    payload = data.model_dump(mode="json")
+    payload.setdefault("anno", date.today().year)
+    db_obj = SegnaleticaOrizzontale(**payload)
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)
@@ -23,7 +26,8 @@ def update_segnaletica_orizzontale(db: Session, so_id: str, data):
     db_obj = db.query(SegnaleticaOrizzontale).filter(SegnaleticaOrizzontale.id == so_id).first()
     if not db_obj:
         return None
-    for key, value in data.dict().items():
+    payload = data.model_dump(mode="json", exclude_unset=True)
+    for key, value in payload.items():
         setattr(db_obj, key, value)
     db.commit()
     db.refresh(db_obj)

--- a/app/routes/signage_horizontal.py
+++ b/app/routes/signage_horizontal.py
@@ -7,6 +7,7 @@ from app.dependencies import get_db
 from app.schemas.segnaletica_orizzontale import (
     SegnaleticaOrizzontaleCreate,
     SegnaleticaOrizzontaleResponse,
+    SegnaleticaOrizzontaleUpdate,
 )
 from app.crud import segnaletica_orizzontale as crud
 from app.services.signage_horizontal import build_signage_horizontal_pdf
@@ -32,7 +33,7 @@ def create_record(data: SegnaleticaOrizzontaleCreate, db: Session = Depends(get_
 
 
 @router.put("/{record_id}", response_model=SegnaleticaOrizzontaleResponse)
-def update_record(record_id: str, data: SegnaleticaOrizzontaleCreate, db: Session = Depends(get_db)):
+def update_record(record_id: str, data: SegnaleticaOrizzontaleUpdate, db: Session = Depends(get_db)):
     db_obj = crud.update_segnaletica_orizzontale(db, record_id, data)
     if not db_obj:
         raise HTTPException(status_code=404, detail="Segnaletica orizzontale not found")

--- a/app/schemas/segnaletica_orizzontale.py
+++ b/app/schemas/segnaletica_orizzontale.py
@@ -15,6 +15,12 @@ class SegnaleticaOrizzontaleResponse(SegnaleticaOrizzontaleCreate):
     }
 
 
+class SegnaleticaOrizzontaleUpdate(BaseModel):
+    azienda: str | None = None
+    descrizione: str | None = None
+    anno: int | None = None
+
+
 class SignageInventoryItem(BaseModel):
     """Aggregated inventory entry used by inventory endpoints."""
 


### PR DESCRIPTION
## Summary
- default the year on horizontal signage creation
- add update schema for signage horizontal
- support partial updates in CRUD and route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687cc131467c83238a28acb361253ab2