### PR TITLE
Refactor signage import rows

### DIFF
--- a/app/services/segnaletica_orizzontale_import.py
+++ b/app/services/segnaletica_orizzontale_import.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from datetime import date
 from typing import Any, Dict, List
 from fastapi import HTTPException
 
@@ -27,7 +26,6 @@ def parse_excel(path: str) -> List[Dict[str, Any]]:
             {
                 "azienda": str(azienda).strip(),
                 "descrizione": str(descr).strip(),
-                "anno": date.today().year,
             }
         )
     return rows


### PR DESCRIPTION
## Summary
- remove `anno` from `segnaletica_orizzontale_import.parse_excel`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687cc3929080832394de1493499ff75a