### PR TITLE
Add signage import-excel endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,15 @@ These routes manage horizontal signage records.
 - `DELETE /inventario/signage-horizontal/{id}` – remove an entry.
 - `GET /inventario/signage-horizontal/years` – list stored years.
 - `GET /inventario/signage-horizontal/pdf?year=<YEAR>` – download the inventory PDF.
+- `POST /inventario/signage-horizontal/import-excel` – import entries from an Excel file.
+
+Upload a workbook containing `azienda` and `descrizione` columns to create
+records in bulk:
+
+```bash
+curl -X POST -F "file=@signage.xlsx" \
+  http://localhost:8000/inventario/signage-horizontal/import-excel
+```
 
 ## Segnalazioni endpoints
 


### PR DESCRIPTION
## Summary
- implement `/inventario/signage-horizontal/import-excel` endpoint
- document usage in README
- add unit tests for the new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687cc6231d908323b2005a1c3439f1cd