### PR TITLE
Clean signage schemas

### DIFF
--- a/app/schemas/segnaletica_orizzontale.py
+++ b/app/schemas/segnaletica_orizzontale.py
@@ -6,13 +6,9 @@ class SegnaleticaOrizzontaleCreate(BaseModel):
     descrizione: str
 
 
-class SegnaleticaOrizzontaleUpdate(BaseModel):
-    azienda: str | None = None
-    descrizione: str | None = None
-
-
 class SegnaleticaOrizzontaleResponse(SegnaleticaOrizzontaleCreate):
     id: str
+    anno: int
 
     model_config = {
         "from_attributes": True,
@@ -22,7 +18,6 @@ class SegnaleticaOrizzontaleResponse(SegnaleticaOrizzontaleCreate):
 class SegnaleticaOrizzontaleUpdate(BaseModel):
     azienda: str | None = None
     descrizione: str | None = None
-    anno: int | None = None
 
 
 class SignageInventoryItem(BaseModel):

--- a/tests/test_segnaletica_orizzontale.py
+++ b/tests/test_segnaletica_orizzontale.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from pathlib import Path
 from unittest.mock import patch
 import os
+import datetime
 
 from app.main import app
 
@@ -9,27 +10,28 @@ client = TestClient(app)
 
 
 def test_create_signage_horizontal(setup_db):
-    data = {"azienda": "ACME", "descrizione": "Linea", "anno": 2024}
+    data = {"azienda": "ACME", "descrizione": "Linea"}
     res = client.post("/inventario/signage-horizontal/", json=data)
     assert res.status_code == 200
     body = res.json()
     assert body["azienda"] == "ACME"
     assert body["descrizione"] == "Linea"
-    assert body["anno"] == 2024
+    assert body["anno"] == datetime.date.today().year
     assert "id" in body
 
 
 def test_update_signage_horizontal(setup_db):
-    base = {"azienda": "ACME", "descrizione": "Old", "anno": 2023}
+    base = {"azienda": "ACME", "descrizione": "Old"}
     res = client.post("/inventario/signage-horizontal/", json=base)
     rec_id = res.json()["id"]
-    update = {"azienda": "Beta", "descrizione": "New", "anno": 2024}
+    year = res.json()["anno"]
+    update = {"azienda": "Beta", "descrizione": "New"}
     res = client.put(f"/inventario/signage-horizontal/{rec_id}", json=update)
     assert res.status_code == 200
     data = res.json()
     assert data["azienda"] == "Beta"
     assert data["descrizione"] == "New"
-    assert data["anno"] == 2024
+    assert data["anno"] == year
 
 
 def test_list_signage_horizontal(setup_db):


### PR DESCRIPTION
## Summary
- consolidate schemas for signage_horizontal
- expose `anno` in SegnaleticaOrizzontaleResponse
- adjust tests to omit year when creating and updating entries

## Testing
- `pytest tests/test_segnaletica_orizzontale.py::test_create_signage_horizontal -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687cc622db048323bc01cd2f0ce49c22