### PR TITLE
Implement unified signage import

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,7 @@ These routes manage horizontal signage records.
 - `DELETE /inventario/signage-horizontal/{id}` – remove an entry.
 - `GET /inventario/signage-horizontal/years` – list stored years.
 - `GET /inventario/signage-horizontal/pdf?year=<YEAR>` – download the inventory PDF.
-- `POST /inventario/signage-horizontal/import` – import entries from an Excel file and return a PDF summary.
-- `POST /inventario/signage-horizontal/import-excel` – import entries from an Excel file.
+- `POST /inventario/signage-horizontal/import` – upload an Excel or CSV file and receive a PDF summary.
 
 Upload a workbook containing `azienda` and `descrizione` columns.
 To receive a PDF summary, call `/inventario/signage-horizontal/import`:
@@ -355,13 +354,6 @@ To receive a PDF summary, call `/inventario/signage-horizontal/import`:
 ```bash
 curl -X POST -F "file=@signage.xlsx" \
   http://localhost:8000/inventario/signage-horizontal/import -o inventory.pdf
-```
-
-To create records and get them back as JSON, use `/inventario/signage-horizontal/import-excel`:
-
-```bash
-curl -X POST -F "file=@signage.xlsx" \
-  http://localhost:8000/inventario/signage-horizontal/import-excel
 ```
 
 ## Segnalazioni endpoints

--- a/app/services/segnaletica_orizzontale_import.py
+++ b/app/services/segnaletica_orizzontale_import.py
@@ -1,10 +1,20 @@
 import pandas as pd
 from typing import Any, Dict, List
 from fastapi import HTTPException
+from pathlib import Path
 
 
-def parse_excel(path: str) -> List[Dict[str, Any]]:
-    df = pd.read_excel(path)
+def parse_file(path: str) -> List[Dict[str, Any]]:
+    """Return rows with ``azienda`` and ``descrizione`` from ``path``.
+
+    The file may be an Excel workbook or a CSV document. Only the
+    ``azienda`` and ``descrizione`` columns are considered. Extra columns
+    are ignored.
+    """
+    if Path(path).suffix.lower() == ".csv":
+        df = pd.read_csv(path)
+    else:
+        df = pd.read_excel(path)
     lower_cols = {c.lower(): c for c in df.columns}
     required = {"azienda", "descrizione"}
     missing = required - set(lower_cols.keys())
@@ -29,3 +39,7 @@ def parse_excel(path: str) -> List[Dict[str, Any]]:
             }
         )
     return rows
+
+
+# ``parse_excel`` is kept for backward compatibility
+parse_excel = parse_file


### PR DESCRIPTION
## Summary
- accept both XLSX and CSV in signage import service
- remove legacy `/import-excel` route and update `/import` handling
- log newly created records
- adjust docs for unified import
- update tests for revised behaviour

## Testing
- `pytest -k segnaletica_orizzontale -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687ce68b6c948323accf2ebcdfe92a7a