### PR TITLE
Add stato field to ToDo

### DIFF
--- a/app/models/todo.py
+++ b/app/models/todo.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
 from app.database import Base
 import uuid
+from app.schemas.todo import StatoToDo
 
 
 class ToDo(Base):
@@ -9,5 +10,6 @@ class ToDo(Base):
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
     descrizione = Column(String, nullable=False)
     scadenza = Column(DateTime, nullable=False)
+    stato = Column(String(30), nullable=False, default=StatoToDo.ATTIVO.value)
     user_id = Column(String, ForeignKey("users.id"), nullable=False)
     user = relationship("User", back_populates="todos")

--- a/app/schemas/todo.py
+++ b/app/schemas/todo.py
@@ -1,10 +1,17 @@
 from pydantic import BaseModel
 from datetime import datetime
+from enum import Enum
+
+
+class StatoToDo(str, Enum):
+    ATTIVO = "ATTIVO"
+    ARCHIVIATO = "ARCHIVIATO"
 
 
 class ToDoCreate(BaseModel):
     descrizione: str
     scadenza: datetime
+    stato: StatoToDo = StatoToDo.ATTIVO
 
 
 class ToDoResponse(ToDoCreate):

--- a/migrations/versions/0014_add_stato_to_todos.py
+++ b/migrations/versions/0014_add_stato_to_todos.py
@@ -1,0 +1,26 @@
+"""add stato column to todos"""
+
+from alembic import op
+import sqlalchemy as sa
+from app.schemas.todo import StatoToDo
+
+revision = "0014_add_stato_to_todos"
+down_revision = "0013_remove_horizontal_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "todos",
+        sa.Column(
+            "stato",
+            sa.String(length=30),
+            nullable=False,
+            server_default=StatoToDo.ATTIVO.value,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("todos", "stato")

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -27,6 +27,7 @@ def test_create_todo(setup_db):
     data = response.json()
     assert data["descrizione"] == "Task"
     assert data["user_id"] == user_id
+    assert data["stato"] == "ATTIVO"
     assert "id" in data
 
 
@@ -44,7 +45,9 @@ def test_update_todo(setup_db):
         headers=headers,
     )
     assert response.status_code == 200
-    assert response.json()["descrizione"] == "New"
+    data = response.json()
+    assert data["descrizione"] == "New"
+    assert data["stato"] == "ATTIVO"
 
 
 def test_list_todos(setup_db):
@@ -63,6 +66,7 @@ def test_list_todos(setup_db):
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2
+    assert all(item["stato"] == "ATTIVO" for item in data)
 
 
 def test_delete_todo(setup_db):
@@ -106,3 +110,4 @@ def test_user_isolated_todos(setup_db):
     assert len(res2.json()) == 1
     assert all(t["user_id"] == id1 for t in res1.json())
     assert all(t["user_id"] == id2 for t in res2.json())
+    assert all(t["stato"] == "ATTIVO" for t in res1.json() + res2.json())


### PR DESCRIPTION
## Summary
- add `StatoToDo` enum and include a `stato` field in `ToDoCreate`
- update ToDo ORM model with the new column
- create Alembic migration to add `stato` column
- adjust ToDo tests for the new field

## Testing
- `black app/schemas/todo.py app/models/todo.py tests/test_todo.py migrations/versions/0014_add_stato_to_todos.py`
- `flake8 app/schemas/todo.py app/models/todo.py tests/test_todo.py migrations/versions/0014_add_stato_to_todos.py` *(fails: command not found)*
- `pytest -k todo -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e746af9848323946f725d5fa039e3